### PR TITLE
Fix registration exception caused by validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export
 
 # Local config
 CONTAINER_NAME=cashtrack_api
-CONTAINER_PORT=8080
+CONTAINER_PORT=8081
 
 # Base deploy config
 BASE_REPO=cashtrack/base-php
@@ -51,6 +51,21 @@ start:
       -v $(WORKDIR):/app \
       --net cash-track-local \
       $(IMAGE_DEV) \
+      -o "http.pool.debug=true" \
+      -o "logs.mode=development" \
+      -o "logs.encoding=console" \
+      -o "logs.level=debug"
+
+start-prod:
+	docker run \
+      --rm \
+      --name $(CONTAINER_NAME) \
+      --platform=linux/amd64 \
+      -p $(CONTAINER_PORT):8080 \
+      --env-file .env \
+      -v $(WORKDIR)/runtime/prod:/app/runtime \
+      --net cash-track-local \
+      cashtrack/api:1.9.6 \
       -o "http.pool.debug=true" \
       -o "logs.mode=development" \
       -o "logs.encoding=console" \

--- a/app/src/Database/Typecast/JsonTypecast.php
+++ b/app/src/Database/Typecast/JsonTypecast.php
@@ -42,7 +42,7 @@ final class JsonTypecast implements CastableInterface, UncastableInterface
     public function cast(array $data): array
     {
         foreach ($this->rules as $column => $rule) {
-            if (! isset($data[$column]) || !is_string($data[$column])) {
+            if (! isset($data[$column]) || !is_string($data[$column]) || $data[$column] === '') {
                 continue;
             }
 

--- a/app/src/Security/UniqueChecker.php
+++ b/app/src/Security/UniqueChecker.php
@@ -44,7 +44,12 @@ final class UniqueChecker extends AbstractChecker
             $select->where($field, '!=', $value);
         }
 
-        return $select->fetchOne() === null;
+        try {
+            return $select->fetchOne() === null;
+        } catch (\Throwable) {
+            // If an error occurs, most likely related to found user, we assume the value is not unique.
+            return false;
+        }
     }
 
     private function withValues(array $fields): array

--- a/app/src/Service/Encrypter/AES256GCM.php
+++ b/app/src/Service/Encrypter/AES256GCM.php
@@ -34,6 +34,10 @@ final class AES256GCM implements CipherInterface
     #[\Override]
     public function decrypt(string $payload, string $key): string
     {
+        if ($payload === '') {
+            return '';
+        }
+
         $packet = base64_decode($payload);
         $ivLength = (int) openssl_cipher_iv_length(static::ALGO);
         $iv = substr($packet, 0, $ivLength);


### PR DESCRIPTION
Bug report received saying an error occurs during registration.

- It was found that if nickname used for existing user, which has incorrect `options` value stored, caused an error by trying to decode invalid JSON.
- additionally found that if empty string tried to be decrypted using chipher with IV, it caused exception because of empty string.