### PR TITLE
security: upgrade phpseclib/phpseclib to 3.0.50

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5546,16 +5546,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.49",
+            "version": "3.0.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "6233a1e12584754e6b5daa69fe1289b47775c1b9"
+                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/6233a1e12584754e6b5daa69fe1289b47775c1b9",
-                "reference": "6233a1e12584754e6b5daa69fe1289b47775c1b9",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
+                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
                 "shasum": ""
             },
             "require": {
@@ -5636,7 +5636,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.49"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.50"
             },
             "funding": [
                 {
@@ -5652,7 +5652,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T09:17:28+00:00"
+            "time": "2026-03-19T02:57:58+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",


### PR DESCRIPTION
## Summary

Fixes Dependabot alert [#25](https://github.com/cash-track/api/security/dependabot/25): `phpseclib/phpseclib` AES-CBC unpadding is susceptible to a **padding oracle timing attack** (high severity).

- Vulnerable range: `>= 3.0.0, <= 3.0.49`
- Fixed in: `3.0.50`
- `phpseclib` is a transitive dependency — only `composer.lock` is updated

Static analysis (`phpcs`, `psalm`) passes with no errors.