### PR TITLE
fix(api): drop credProps extension from passkey login options

### DIFF
--- a/app/src/Service/Auth/Passkey/PasskeyService.php
+++ b/app/src/Service/Auth/Passkey/PasskeyService.php
@@ -112,7 +112,6 @@ class PasskeyService
             rpId: $this->config->getServiceId(),
             userVerification: PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED,
             timeout: $this->config->getTimeout(),
-            extensions: $this->getExtensions(),
         );
 
         $this->storeRequestOptions($challenge, $options);

--- a/tests/Feature/Controller/Auth/PasskeyControllerTest.php
+++ b/tests/Feature/Controller/Auth/PasskeyControllerTest.php
@@ -92,10 +92,10 @@ class PasskeyControllerTest extends TestCase implements DatabaseTransaction
         $this->assertArrayHasKey('userVerification', $decoded);
         $this->assertEquals('required', $decoded['userVerification']);
 
-        $this->assertArrayHasKey('extensions', $decoded);
-        $this->assertIsArray($decoded['extensions']);
-        $this->assertArrayHasKey('credProps', $decoded['extensions']);
-        $this->assertTrue($decoded['extensions']['credProps']);
+        // credProps is a registration-only extension (reports whether the *created* credential
+        // is discoverable); it must not be attached to login/authentication options, or browsers
+        // reject the ceremony with NotSupportedError.
+        $this->assertArrayNotHasKey('extensions', $decoded);
 
         $this->assertArrayHasKey('timeout', $decoded);
         $this->assertEquals($config->getTimeout(), $decoded['timeout']);


### PR DESCRIPTION
## Problem statement

Passkey login (`POST /auth/login/passkey/init` → `navigator.credentials.get()`) has been silently broken for any client that forwards the server's authentication options in full. `PasskeyService::initAuth()` reuses the same `getExtensions()` helper as registration, which attaches a `credProps` extension to the returned `PublicKeyCredentialRequestOptions`. `credProps` is only meaningful for credential *creation* — it reports whether the credential that was just created is discoverable. Browsers correctly reject a `.get()` (authentication) call carrying it: Chromium throws `NotSupportedError: The 'credProps' extension is only valid when creating a credential`.

This has been masked in production so far by an unrelated bug in the website client (see the companion `website` PR), which never forwarded the real extensions object into the ceremony at all. Fixing the client-side bug on its own would have made login fail for 100% of users, since it starts forwarding the full — currently invalid — options object.

## Changes

- `PasskeyService::initAuth()`: removed the `extensions` argument from the `PublicKeyCredentialRequestOptions::create()` call. The parameter is optional/nullable, so login options now simply omit `extensions` entirely rather than sending an empty or invalid value.
- `PasskeyControllerTest::testInit()`: the existing assertion asserted the buggy behavior (`credProps` present in the response). Updated to assert `extensions` is absent from login options, with a comment explaining why.

## Verification

- `composer phpunit` — all passkey-related tests pass (11 tests, 72 assertions).
- `composer phpcs` — no new violations introduced by this change.
- `composer psalm` (scoped to the changed file) — no errors found.
- Verified against the live local stack: decoded a real `POST /auth/login/passkey/init` response post-fix and confirmed `extensions` is fully absent from the JSON payload.
- End-to-end: paired with the website fix, a real WebAuthn login ceremony (via a CDP virtual authenticator, Playwright) now resolves successfully and the login POST succeeds — see the `frontend` E2E PR (S23 / issue #130) for the automated coverage.