### PR TITLE
fix(api): security dependency upgrades (4 advisories)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2770,22 +2770,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.13.1",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/55901a76dfd2006a0cc012b9e3c5b487f796478d",
-                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12.3",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -2797,8 +2797,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.6",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -2878,7 +2878,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.13.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -2894,20 +2894,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-29T20:14:18+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
@@ -2962,7 +2962,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -2978,20 +2978,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:23:43+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.3",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
-                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -3081,7 +3081,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -3097,7 +3097,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-23T15:21:08+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "illuminate/collections",


### PR DESCRIPTION
## Security dependency upgrades — `api`

Source of findings: **Dependabot**

| Severity | Package | From → To | CVE / GHSA |
|---|---|---|---|
| Medium | `guzzlehttp/guzzle` | 7.13.1 → 7.15.1 | [GHSA-h95v-h523-3mw8](https://github.com/advisories/GHSA-h95v-h523-3mw8) |
| Medium | `guzzlehttp/guzzle` | 7.13.1 → 7.15.1 | [GHSA-f283-ghqc-fg79](https://github.com/advisories/GHSA-f283-ghqc-fg79) |
| Medium | `guzzlehttp/guzzle` | 7.13.1 → 7.15.1 | [GHSA-wm3w-8rrp-j577](https://github.com/advisories/GHSA-wm3w-8rrp-j577) |
| Medium | `guzzlehttp/guzzle` | 7.13.1 → 7.15.1 | [GHSA-94pj-82f3-465w](https://github.com/advisories/GHSA-94pj-82f3-465w) |

### What changed
- `composer update guzzlehttp/guzzle -W` → guzzle 7.13.1 → 7.15.1, plus the two packages it pulls with it: `guzzlehttp/promises` 2.5.0 → 2.5.1 and `guzzlehttp/psr7` 2.12.3 → 2.13.0.
- Guzzle is a **transitive** dependency here — it arrives via `aws/aws-sdk-php`, `kreait/firebase-php`, `google/apiclient`, `google/auth`, `google/cloud-core` and `kreait/firebase-tokens`. All six already declare `^7.x`, so 7.15.1 satisfies every constraint and **no `composer.json` edit was needed**.
- `composer.lock` is the only file in the diff.

### Codebase changes
None — dependency bumps only.

### Verification
- `composer audit --locked` → `No security vulnerability advisories found.`
- `composer psalm` → `No errors found!` (2782 files scanned, types inferred for 97.9% of the codebase).

Full `composer phpunit` was not run — it needs the `tests/docker-compose.yml` stack. Since no application code changed and Psalm is clean against the new Guzzle signatures, CI is the right place to confirm the suite.

### Deferred / no fix available
None — all four advisories cleared.
