### PR TITLE
fix(api): reject unauthenticated actors in AuthAwareController with 401

### DIFF
--- a/app/src/Controller/Auth/ConfirmEmailController.php
+++ b/app/src/Controller/Auth/ConfirmEmailController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Auth;
+
+use App\Service\Auth\EmailConfirmationService;
+use Psr\Http\Message\ResponseInterface;
+use Spiral\Http\ResponseWrapper;
+use Spiral\Router\Annotation\Route;
+use Spiral\Translator\Traits\TranslatorTrait;
+
+/**
+ * Public counterpart of {@see EmailConfirmationsController}. The confirmation link is opened
+ * from an email, so this action must stay off AuthAwareController.
+ */
+final class ConfirmEmailController
+{
+    use TranslatorTrait;
+
+    public function __construct(
+        protected readonly ResponseWrapper $response,
+        protected readonly EmailConfirmationService $emailConfirmationService,
+    ) {
+    }
+
+    #[Route(route: '/auth/email/confirmation/confirm/<token>', name: 'auth.email.confirm')]
+    public function confirm(string $token): ResponseInterface
+    {
+        try {
+            $this->emailConfirmationService->confirm($token);
+        } catch (\Throwable $exception) {
+            return $this->response->json([
+                'message' => $this->say('email_confirmation_confirm_failure'),
+                'error' => $exception->getMessage(),
+            ], 400);
+        }
+
+        return $this->response->json([
+            'message' => $this->say('email_confirmation_ok'),
+        ]);
+    }
+}

--- a/app/src/Controller/Auth/EmailConfirmationsController.php
+++ b/app/src/Controller/Auth/EmailConfirmationsController.php
@@ -44,23 +44,6 @@ final class EmailConfirmationsController extends AuthAwareController
         return $this->emailConfirmationView->json($confirmation);
     }
 
-    #[Route(route: '/auth/email/confirmation/confirm/<token>', name: 'auth.email.confirm')]
-    public function confirm(string $token): ResponseInterface
-    {
-        try {
-            $this->emailConfirmationService->confirm($token);
-        } catch (\Throwable $exception) {
-            return $this->response->json([
-                'message' => $this->say('email_confirmation_confirm_failure'),
-                'error' => $exception->getMessage(),
-            ], 400);
-        }
-
-        return $this->response->json([
-            'message' => $this->say('email_confirmation_ok'),
-        ]);
-    }
-
     #[Route(route: '/auth/email/confirmation/resend', name: 'auth.email.resend', methods: 'POST', group: 'auth')]
     public function reSend(): ResponseInterface
     {

--- a/app/src/Controller/AuthAwareController.php
+++ b/app/src/Controller/AuthAwareController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Database\User;
+use App\Exception\AuthenticationRequiredException;
 use App\Exception\UnconfirmedProfileException;
 use Spiral\Auth\AuthContextInterface;
 use Spiral\Translator\Traits\TranslatorTrait;
@@ -15,12 +16,18 @@ abstract class AuthAwareController
 
     protected User $user;
 
+    /**
+     * Every route on a subclass must carry `group: 'auth'` — the constructor refuses to build
+     * the controller otherwise, rather than leaving $user unset for the first read to fatal on.
+     *
+     * @throws AuthenticationRequiredException
+     */
     public function __construct(AuthContextInterface $auth)
     {
         $user = $auth->getActor();
 
         if (! $user instanceof User) {
-            return;
+            throw new AuthenticationRequiredException($this->say('error_authentication_required'));
         }
 
         $this->user = $user;

--- a/app/src/Exception/AuthenticationRequiredException.php
+++ b/app/src/Exception/AuthenticationRequiredException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+final class AuthenticationRequiredException extends \Exception
+{
+}

--- a/app/src/Exception/ViewRenderer.php
+++ b/app/src/Exception/ViewRenderer.php
@@ -12,7 +12,8 @@ use Spiral\Http\ErrorHandler\RendererInterface;
 final class ViewRenderer implements RendererInterface
 {
     const MAP = [
-        UnconfirmedProfileException::class => 403
+        UnconfirmedProfileException::class => 403,
+        AuthenticationRequiredException::class => 401,
     ];
 
     public function __construct(

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -366,8 +366,6 @@ paths:
           schema:
             type: string
       responses:
-        "401":
-          $ref: "#/components/responses/Unauthorized"
         "200":
           description: Email confirmed successfully
         "400":

--- a/tests/Feature/Controller/Auth/ConfirmEmailControllerTest.php
+++ b/tests/Feature/Controller/Auth/ConfirmEmailControllerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controller\Auth;
+
+use App\Database\EntityHeader;
+use App\Database\User;
+use App\Mail\WelcomeMail;
+use App\Service\Mailer\MailerInterface;
+use Tests\DatabaseTransaction;
+use Tests\Factories\EmailConfirmationFactory;
+use Tests\Factories\UserFactory;
+use Tests\Fixtures;
+use Tests\TestCase;
+
+class ConfirmEmailControllerTest extends TestCase implements DatabaseTransaction
+{
+    /**
+     * @var \Tests\Factories\UserFactory
+     */
+    protected UserFactory $userFactory;
+
+    /**
+     * @var \Tests\Factories\EmailConfirmationFactory
+     */
+    protected EmailConfirmationFactory $emailConfirmationFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userFactory = $this->getContainer()->get(UserFactory::class);
+        $this->emailConfirmationFactory = $this->getContainer()->get(EmailConfirmationFactory::class);
+    }
+
+    public function testConfirm(): void
+    {
+        $user = $this->userFactory->create(UserFactory::emailNotConfirmed());
+
+        $mock = $this->getMockBuilder(MailerInterface::class)
+                     ->disableOriginalConstructor()
+                     ->getMock();
+
+        $mock->expects($this->once())
+             ->method('send')
+             ->with($this->callback(function ($mail) use ($user) {
+                 $this->assertInstanceOf(WelcomeMail::class, $mail);
+                 $this->assertInstanceOf(EntityHeader::class, $mail->userHeader);
+                 $this->assertEquals(User::class, $mail->userHeader->role);
+                 $this->assertEquals(['id' => $user->id], $mail->userHeader->params);
+
+                 return true;
+             }));
+
+        $this->getContainer()->bind(MailerInterface::class, fn () => $mock);
+
+
+        $confirmation = EmailConfirmationFactory::notExpired();
+        $confirmation->email = $user->email;
+        $confirmation = $this->emailConfirmationFactory->create($confirmation);
+
+        $response = $this->post("/auth/email/confirmation/confirm/{$confirmation->token}");
+
+        $response->assertOk();
+
+        $body = $this->getJsonResponseBody($response);
+
+        $this->assertArrayHasKey('message', $body);
+
+        $this->assertDatabaseMissing('email_confirmations', [
+            'email' => $user->email,
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'is_email_confirmed' => true,
+        ], [
+            'email' => $user->email,
+        ]);
+    }
+
+    public function testConfirmWithExpiredToken(): void
+    {
+        $user = $this->userFactory->create(UserFactory::emailNotConfirmed());
+
+        $confirmation = EmailConfirmationFactory::expired();
+        $confirmation->email = $user->email;
+        $confirmation = $this->emailConfirmationFactory->create($confirmation);
+
+        $response = $this->post("/auth/email/confirmation/confirm/{$confirmation->token}");
+
+        $response->assertStatus(400);
+
+        $body = $this->getJsonResponseBody($response);
+
+        $this->assertArrayHasKey('message', $body);
+        $this->assertArrayHasKey('error', $body);
+
+        $this->assertDatabaseHas('users', [
+            'is_email_confirmed' => false,
+        ], [
+            'email' => $user->email,
+        ]);
+    }
+
+    public function testConfirmWithMissingToken(): void
+    {
+        $user = $this->userFactory->create(UserFactory::emailNotConfirmed());
+
+        $token = Fixtures::string(16);
+
+        $response = $this->post("/auth/email/confirmation/confirm/{$token}");
+
+        $response->assertStatus(400);
+
+        $body = $this->getJsonResponseBody($response);
+
+        $this->assertArrayHasKey('message', $body);
+        $this->assertArrayHasKey('error', $body);
+
+        $this->assertDatabaseHas('users', [
+            'is_email_confirmed' => false,
+        ], [
+            'email' => $user->email,
+        ]);
+    }
+
+    public function testConfirmMissingUser(): void
+    {
+        $user = $this->userFactory->create(UserFactory::emailNotConfirmed());
+
+        $confirmation = EmailConfirmationFactory::notExpired();
+        $confirmation->email = Fixtures::email();
+        $confirmation = $this->emailConfirmationFactory->create($confirmation);
+
+        $response = $this->post("/auth/email/confirmation/confirm/{$confirmation->token}");
+
+        $response->assertStatus(400);
+
+        $body = $this->getJsonResponseBody($response);
+
+        $this->assertArrayHasKey('message', $body);
+        $this->assertArrayHasKey('error', $body);
+
+        $this->assertDatabaseMissing('users', [
+            'email' => $user->email,
+            'is_email_confirmed' => true,
+        ]);
+
+        $this->assertDatabaseMissing('users', [
+            'email' => $confirmation->email,
+            'is_email_confirmed' => true,
+        ]);
+    }
+}

--- a/tests/Feature/Controller/Auth/EmailConfirmationsControllerTest.php
+++ b/tests/Feature/Controller/Auth/EmailConfirmationsControllerTest.php
@@ -7,15 +7,13 @@ namespace Tests\Feature\Controller\Auth;
 use App\Database\EntityHeader;
 use App\Database\User;
 use App\Mail\EmailConfirmationMail;
-use App\Mail\WelcomeMail;
 use App\Service\Mailer\MailerInterface;
 use Tests\DatabaseTransaction;
 use Tests\Factories\EmailConfirmationFactory;
 use Tests\Factories\UserFactory;
-use Tests\Fixtures;
 use Tests\TestCase;
 
-class EmailConfirmationControllerTest extends TestCase implements DatabaseTransaction
+class EmailConfirmationsControllerTest extends TestCase implements DatabaseTransaction
 {
     /**
      * @var \Tests\Factories\UserFactory
@@ -73,125 +71,6 @@ class EmailConfirmationControllerTest extends TestCase implements DatabaseTransa
 
         $this->assertArrayHasKey('data', $body);
         $this->assertNull($body['data']);
-    }
-
-    public function testConfirm(): void
-    {
-        $user = $this->userFactory->create(UserFactory::emailNotConfirmed());
-
-        $mock = $this->getMockBuilder(MailerInterface::class)
-                     ->disableOriginalConstructor()
-                     ->getMock();
-
-        $mock->expects($this->once())
-             ->method('send')
-             ->with($this->callback(function ($mail) use ($user) {
-                 $this->assertInstanceOf(WelcomeMail::class, $mail);
-                 $this->assertInstanceOf(EntityHeader::class, $mail->userHeader);
-                 $this->assertEquals(User::class, $mail->userHeader->role);
-                 $this->assertEquals(['id' => $user->id], $mail->userHeader->params);
-
-                 return true;
-             }));
-
-        $this->getContainer()->bind(MailerInterface::class, fn () => $mock);
-
-
-        $confirmation = EmailConfirmationFactory::notExpired();
-        $confirmation->email = $user->email;
-        $confirmation = $this->emailConfirmationFactory->create($confirmation);
-
-        $response = $this->post("/auth/email/confirmation/confirm/{$confirmation->token}");
-
-        $response->assertOk();
-
-        $body = $this->getJsonResponseBody($response);
-
-        $this->assertArrayHasKey('message', $body);
-
-        $this->assertDatabaseMissing('email_confirmations', [
-            'email' => $user->email,
-        ]);
-
-        $this->assertDatabaseHas('users', [
-            'is_email_confirmed' => true,
-        ], [
-            'email' => $user->email,
-        ]);
-    }
-
-    public function testConfirmWithExpiredToken(): void
-    {
-        $user = $this->userFactory->create(UserFactory::emailNotConfirmed());
-
-        $confirmation = EmailConfirmationFactory::expired();
-        $confirmation->email = $user->email;
-        $confirmation = $this->emailConfirmationFactory->create($confirmation);
-
-        $response = $this->post("/auth/email/confirmation/confirm/{$confirmation->token}");
-
-        $response->assertStatus(400);
-
-        $body = $this->getJsonResponseBody($response);
-
-        $this->assertArrayHasKey('message', $body);
-        $this->assertArrayHasKey('error', $body);
-
-        $this->assertDatabaseHas('users', [
-            'is_email_confirmed' => false,
-        ], [
-            'email' => $user->email,
-        ]);
-    }
-
-    public function testConfirmWithMissingToken(): void
-    {
-        $user = $this->userFactory->create(UserFactory::emailNotConfirmed());
-
-        $token = Fixtures::string(16);
-
-        $response = $this->post("/auth/email/confirmation/confirm/{$token}");
-
-        $response->assertStatus(400);
-
-        $body = $this->getJsonResponseBody($response);
-
-        $this->assertArrayHasKey('message', $body);
-        $this->assertArrayHasKey('error', $body);
-
-        $this->assertDatabaseHas('users', [
-            'is_email_confirmed' => false,
-        ], [
-            'email' => $user->email,
-        ]);
-    }
-
-    public function testConfirmMissingUser(): void
-    {
-        $user = $this->userFactory->create(UserFactory::emailNotConfirmed());
-
-        $confirmation = EmailConfirmationFactory::notExpired();
-        $confirmation->email = Fixtures::email();
-        $confirmation = $this->emailConfirmationFactory->create($confirmation);
-
-        $response = $this->post("/auth/email/confirmation/confirm/{$confirmation->token}");
-
-        $response->assertStatus(400);
-
-        $body = $this->getJsonResponseBody($response);
-
-        $this->assertArrayHasKey('message', $body);
-        $this->assertArrayHasKey('error', $body);
-
-        $this->assertDatabaseMissing('users', [
-            'email' => $user->email,
-            'is_email_confirmed' => true,
-        ]);
-
-        $this->assertDatabaseMissing('users', [
-            'email' => $confirmation->email,
-            'is_email_confirmed' => true,
-        ]);
     }
 
     public function testReSendRequireAuth(): void

--- a/tests/Feature/Controller/MailsControllerTest.php
+++ b/tests/Feature/Controller/MailsControllerTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Tests\Feature\Controller;
 
 use App\Controller\MailsController;
+use App\Database\EntityHeader;
+use App\Database\User;
+use App\Mail\TestMail;
 use App\Service\Mailer\MailerInterface;
 use Spiral\Auth\AuthContextInterface;
 use Spiral\Boot\EnvironmentInterface;
@@ -15,77 +18,78 @@ class MailsControllerTest extends TestCase
 {
     public function testTestDisabledDebugDoNothing(): void
     {
-        $authContext = $this->getMockBuilder(AuthContextInterface::class)->getMock();
-        $authContext->method('getActor')->willReturn(null);
-
-        $this->getContainer()->bind(AuthContextInterface::class, fn () => $authContext);
-        $auth = $this->getContainer()->get(AuthContextInterface::class);
-
-        $mailer = $this->getMockBuilder(MailerInterface::class)->getMock();
+        $mailer = $this->makeMailer();
         $mailer->expects($this->never())->method('send');
 
-        $environment = $this->getMockBuilder(EnvironmentInterface::class)->getMock();
-        $environment->method('get')->with('DEBUG')->willReturn(false);
-
-        $controller = new MailsController($auth, $mailer, $environment);
-        $controller->test();
+        $this->makeController($mailer, UserFactory::make(), debug: false)->test();
     }
 
     public function testTestEnabledDebugSendMessage(): void
     {
         $user = UserFactory::make();
 
-        $authContext = $this->getMockBuilder(AuthContextInterface::class)->getMock();
-        $authContext->method('getActor')->willReturn($user);
+        $mailer = $this->makeMailer();
+        $mailer->expects($this->once())
+               ->method('send')
+               ->with($this->callback($this->isTestMailFor($user)));
 
-        $this->getContainer()->bind(AuthContextInterface::class, fn () => $authContext);
-        $auth = $this->getContainer()->get(AuthContextInterface::class);
-
-        $mailer = $this->getMockBuilder(MailerInterface::class)->getMock();
-        $mailer->expects($this->once())->method('send');
-
-        $environment = $this->getMockBuilder(EnvironmentInterface::class)->getMock();
-        $environment->method('get')->with('DEBUG')->willReturn(true);
-
-        $controller = new MailsController($auth, $mailer, $environment);
-        $controller->test();
+        $this->makeController($mailer, $user, debug: true)->test();
     }
 
     public function testPreviewDisabledDebugDoNothing(): void
     {
-        $authContext = $this->getMockBuilder(AuthContextInterface::class)->getMock();
-        $authContext->method('getActor')->willReturn(null);
-
-        $this->getContainer()->bind(AuthContextInterface::class, fn () => $authContext);
-        $auth = $this->getContainer()->get(AuthContextInterface::class);
-
-        $mailer = $this->getMockBuilder(MailerInterface::class)->getMock();
+        $mailer = $this->makeMailer();
         $mailer->expects($this->never())->method('render');
 
-        $environment = $this->getMockBuilder(EnvironmentInterface::class)->getMock();
-        $environment->method('get')->with('DEBUG')->willReturn(false);
+        $controller = $this->makeController($mailer, UserFactory::make(), debug: false);
 
-        $controller = new MailsController($auth, $mailer, $environment);
-        $controller->preview();
+        $this->assertEquals('ok', $controller->preview());
     }
 
     public function testPreviewEnabledDebugRenderMessage(): void
     {
         $user = UserFactory::make();
 
-        $authContext = $this->getMockBuilder(AuthContextInterface::class)->getMock();
-        $authContext->method('getActor')->willReturn($user);
+        $mailer = $this->makeMailer();
+        $mailer->expects($this->once())
+               ->method('render')
+               ->with($this->callback($this->isTestMailFor($user)))
+               ->willReturn('<html>test</html>');
 
-        $this->getContainer()->bind(AuthContextInterface::class, fn () => $authContext);
-        $auth = $this->getContainer()->get(AuthContextInterface::class);
+        $controller = $this->makeController($mailer, $user, debug: true);
 
-        $mailer = $this->getMockBuilder(MailerInterface::class)->getMock();
-        $mailer->expects($this->once())->method('render');
+        $this->assertEquals('<html>test</html>', $controller->preview());
+    }
+
+    /**
+     * Both routes are `group: 'auth'`, so the actor is always a resolved User — AuthAwareController
+     * refuses to construct otherwise.
+     */
+    private function makeController(MailerInterface $mailer, User $actor, bool $debug): MailsController
+    {
+        $auth = $this->getMockBuilder(AuthContextInterface::class)->getMock();
+        $auth->method('getActor')->willReturn($actor);
 
         $environment = $this->getMockBuilder(EnvironmentInterface::class)->getMock();
-        $environment->method('get')->with('DEBUG')->willReturn(true);
+        $environment->method('get')->with('DEBUG')->willReturn($debug);
 
-        $controller = new MailsController($auth, $mailer, $environment);
-        $controller->preview();
+        return new MailsController($auth, $mailer, $environment);
+    }
+
+    private function makeMailer(): MailerInterface
+    {
+        return $this->getMockBuilder(MailerInterface::class)->getMock();
+    }
+
+    private function isTestMailFor(User $user): \Closure
+    {
+        return function ($mail) use ($user) {
+            $this->assertInstanceOf(TestMail::class, $mail);
+            $this->assertInstanceOf(EntityHeader::class, $mail->userHeader);
+            $this->assertEquals(User::class, $mail->userHeader->role);
+            $this->assertEquals(['id' => $user->id], $mail->userHeader->params);
+
+            return true;
+        };
     }
 }

--- a/tests/Unit/Controller/AuthAwareControllerTest.php
+++ b/tests/Unit/Controller/AuthAwareControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Controller;
+
+use App\Controller\AuthAwareController;
+use App\Database\User;
+use App\Exception\AuthenticationRequiredException;
+use App\Exception\UnconfirmedProfileException;
+use Spiral\Auth\AuthContextInterface;
+use Tests\TestCase;
+
+class AuthAwareControllerTest extends TestCase
+{
+    public function testConstructRejectsMissingActor(): void
+    {
+        $this->expectException(AuthenticationRequiredException::class);
+
+        $this->makeController(null);
+    }
+
+    public function testConstructRejectsForeignActor(): void
+    {
+        $this->expectException(AuthenticationRequiredException::class);
+
+        $this->makeController(new \stdClass());
+    }
+
+    public function testConstructAssignsUser(): void
+    {
+        $user = new User();
+
+        $this->assertSame($user, $this->makeController($user)->actor());
+    }
+
+    public function testVerifyIsProfileConfirmedPassesForConfirmedProfile(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $user = new User();
+        $user->isEmailConfirmed = true;
+
+        $this->makeController($user)->verify();
+    }
+
+    public function testVerifyIsProfileConfirmedRejectsUnconfirmedProfile(): void
+    {
+        $this->expectException(UnconfirmedProfileException::class);
+
+        $this->makeController(new User())->verify();
+    }
+
+    /**
+     * An unresolved actor must never reach verifyIsProfileConfirmed() — that would answer 403
+     * "profile not confirmed" to a caller who simply is not authenticated.
+     */
+    private function makeController(?object $actor)
+    {
+        $auth = $this->getMockBuilder(AuthContextInterface::class)->getMock();
+        $auth->method('getActor')->willReturn($actor);
+
+        return new class ($auth) extends AuthAwareController {
+            public function actor(): User
+            {
+                return $this->user;
+            }
+
+            public function verify(): void
+            {
+                $this->verifyIsProfileConfirmed();
+            }
+        };
+    }
+}

--- a/tests/Unit/Exception/ViewRendererTest.php
+++ b/tests/Unit/Exception/ViewRendererTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Exception;
+
+use App\Exception\AuthenticationRequiredException;
+use App\Exception\UnconfirmedProfileException;
+use App\Exception\ViewRenderer;
+use Laminas\Diactoros\ServerRequest;
+use Tests\TestCase;
+
+class ViewRendererTest extends TestCase
+{
+    private ViewRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->renderer = $this->getContainer()->get(ViewRenderer::class);
+    }
+
+    public function renderExceptionDataProvider(): array
+    {
+        return [
+            'authentication required' => [new AuthenticationRequiredException('Authentication required.'), 500, 401],
+            'unconfirmed profile' => [new UnconfirmedProfileException('Profile is not confirmed.'), 500, 403],
+            'unmapped exception keeps the given code' => [new \RuntimeException('Boom.'), 404, 404],
+        ];
+    }
+
+    /**
+     * @dataProvider renderExceptionDataProvider
+     */
+    public function testRenderException(\Throwable $exception, int $code, int $expectedCode): void
+    {
+        $response = $this->renderer->renderException(
+            new ServerRequest(uri: '/profile', method: 'GET'),
+            $code,
+            $exception,
+        );
+
+        $this->assertEquals($expectedCode, $response->getStatusCode());
+        $this->assertEquals('application/json; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+
+        $body = json_decode((string) $response->getBody(), true);
+
+        $this->assertEquals($expectedCode, $body['status']);
+        $this->assertEquals($exception->getMessage(), $body['error']);
+    }
+}


### PR DESCRIPTION
Closes #207. Implements the first recommended resolution from the issue.

## The bug

`AuthAwareController::__construct` silently `return`ed when `$auth->getActor()` was not a `User`, leaving the typed property `$user` uninitialized. The first read of it throws `Error: Typed property App\Controller\AuthAwareController::$user must not be accessed before initialization` — a 500 with a stack trace where a 401 belongs.

It is not reachable today: `AuthMiddleware` rejects a non-`User` actor before the controller is constructed, so every route carrying `group: 'auth'` is safe. The guard is the route annotation, not the type system — one missing `group` on any of the 15 subclasses turns this into a 500, with nothing in Psalm or phpcs to catch it.

## The fix

- New `App\Exception\AuthenticationRequiredException`, mirroring the existing `UnconfirmedProfileException`.
- `AuthAwareController::__construct` throws it when the actor is not a `User`.
- `ViewRenderer::MAP` maps it to 401, next to `UnconfirmedProfileException => 403`.

Caveat worth knowing: `ErrorHandlerMiddleware` only consults `ViewRenderer` when errors are suppressed, i.e. `DEBUG=false`. Locally with `DEBUG=true` the response is a 500 carrying the message. That is pre-existing behaviour shared with the 403 mapping, not something this PR introduces. If we want the 401 to hold in debug too, the exception needs to extend Spiral's `ClientException\UnauthorizedException` instead — happy to switch.

## Why the email-confirmation route moved

Spiral constructs the controller before invoking the route method, so a throwing constructor rejects **every** route on the class, not just the authenticated ones. Scanning all 15 `AuthAwareController` subclasses, `auth.email.confirm` was the only route without `group: 'auth'` — by design, since the confirmation link is opened from an email by a signed-out user. Left in place it would 401 every confirmation link.

`confirm()` moves **unchanged** — same URL, same route name, same method body — from `Auth\EmailConfirmationsController` to a new `Auth\ConfirmEmailController` that extends nothing. Nothing is removed from the API surface:

\`\`\`
auth.email.confirm | * | /auth/email/confirmation/confirm/<token> | Controller\Auth\ConfirmEmailController->confirm | web
\`\`\`

Named for the action rather than `EmailConfirmationController`, which would be a character away from the plural class still sitting in the same namespace. Its four feature tests move with it verbatim; the remaining test file is renamed to match the controller it now covers.

## Also in here

- `docs/openapi.yaml`: dropped the `401` response from `/auth/email/confirmation/confirm/{token}`. The route is `security: []` and could never return it.
- `MailsControllerTest` rewritten. Both its routes are `group: 'auth'` but the tests fed `getActor() => null` as a don't-care, so the new constructor guard failed them. Rather than patch in a user, the file now shares one controller factory instead of duplicating an 8-line mock setup four times, asserts `preview()`'s return value (previously never checked), verifies the mail is a `TestMail` addressed to the right user, and drops a container bind that was immediately resolved back out. 4 assertions to 14.

## Coverage

New `tests/Unit/Controller/AuthAwareControllerTest.php` (5 cases: null actor, foreign actor, valid actor, confirmed profile, unconfirmed profile) and `tests/Unit/Exception/ViewRendererTest.php` (both mapped exceptions plus an unmapped one entering at 404 to prove passthrough rather than coincidence).

## Verification

- \`composer phpunit\` — OK, 770 tests, 3760 assertions
- \`composer phpcs\` — clean
- \`composer psalm\` — no errors (97.9% type inference)
- \`php app.php route:list\` — all three email-confirmation routes registered with the expected groups

Redocly lint on the OpenAPI change was not run: \`npx\` is broken in my sandbox (returns \`Unknown command\` for every package). The edit is a two-line deletion; worth a CI confirmation.