### PR TITLE
feat(api): support AND/OR tag group combinations in wallet limits

### DIFF
--- a/app/locale/en/messages.php
+++ b/app/locale/en/messages.php
@@ -9,6 +9,7 @@ return [
     'error_loading_default_currency'        => 'Unable to load default currency.',
     'error_password_confirmation_not_match' => 'The password confirmation does not match.',
     'error_wallet_does_not_exists'          => 'One or more wallets does not exists.',
+    'error_limit_tag_groups_invalid'        => 'Tag groups are not valid.',
     'error_nick_name_claimed'               => 'Nick name already claimed.',
     'error_value_is_not_unique'             => 'Value should be unique.',
     'error_profile_not_confirmed'           => 'You are not allowed to perform this action as your profile is not confirmed.',

--- a/app/locale/uk/messages.php
+++ b/app/locale/uk/messages.php
@@ -9,6 +9,7 @@ return [
     'error_loading_default_currency'        => 'Неможливо завантажити валюту за замовчуванням.',
     'error_password_confirmation_not_match' => 'Підтвердження паролю не збігається.',
     'error_wallet_does_not_exists'          => 'Один чи більше гаманець більше не існує.',
+    'error_limit_tag_groups_invalid'        => 'Групи тегів некоректні.',
     'error_nick_name_claimed'               => 'Нікнейм вже зайнято.',
     'error_value_is_not_unique'             => 'Значення має бути унікальним.',
     'error_profile_not_confirmed'           => 'Вам не дозволено здійснити бажану операцію, так як Ваш профіль не підтверджено.',

--- a/app/migrations/20260802.124409_0_create_limit_tag_groups_tables.php
+++ b/app/migrations/20260802.124409_0_create_limit_tag_groups_tables.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Cycle\Migrations\Migration;
+
+class CreateLimitTagGroupsTablesMigration extends Migration
+{
+    public function up(): void
+    {
+        $this->table('limit_tag_groups')
+             ->addColumn('id', 'primary', [
+                 'nullable' => false,
+                 'default'  => null,
+             ])
+             ->addColumn('limit_id', 'integer', [
+                 'nullable' => false,
+                 'default'  => null,
+             ])
+             ->addColumn('connection', 'enum', [
+                 'nullable' => false,
+                 'default'  => 'or',
+                 'values'   => ['and', 'or'],
+             ])
+             ->addIndex(['limit_id'], [
+                 'name'   => 'limit_tag_groups_index_limit_id',
+                 'unique' => false,
+             ])
+             ->addForeignKey(['limit_id'], 'limits', ['id'], [
+                 'name'   => 'limit_tag_groups_foreign_limit_id',
+                 'delete' => 'CASCADE',
+                 'update' => 'CASCADE',
+             ])
+             ->setPrimaryKeys(['id'])
+             ->create();
+
+        $this->table('tag_limit_tag_groups')
+             ->addColumn('id', 'primary', [
+                 'nullable' => false,
+                 'default'  => null,
+             ])
+             ->addColumn('limit_tag_group_id', 'integer', [
+                 'nullable' => false,
+                 'default'  => null,
+             ])
+             ->addColumn('tag_id', 'integer', [
+                 'nullable' => false,
+                 'default'  => null,
+             ])
+             ->addIndex(['limit_tag_group_id', 'tag_id'], [
+                 'name'   => 'tag_limit_tag_groups_index_limit_tag_group_id_tag_id',
+                 'unique' => true,
+             ])
+             ->addIndex(['limit_tag_group_id'], [
+                 'name'   => 'tag_limit_tag_groups_index_limit_tag_group_id',
+                 'unique' => false,
+             ])
+             ->addIndex(['tag_id'], [
+                 'name'   => 'tag_limit_tag_groups_index_tag_id',
+                 'unique' => false,
+             ])
+             ->addForeignKey(['limit_tag_group_id'], 'limit_tag_groups', ['id'], [
+                 'name'   => 'tag_limit_tag_groups_foreign_limit_tag_group_id',
+                 'delete' => 'CASCADE',
+                 'update' => 'CASCADE',
+             ])
+             ->addForeignKey(['tag_id'], 'tags', ['id'], [
+                 'name'   => 'tag_limit_tag_groups_foreign_tag_id',
+                 'delete' => 'CASCADE',
+                 'update' => 'CASCADE',
+             ])
+             ->setPrimaryKeys(['id'])
+             ->create();
+
+        // Backfill: every existing limit gets one AND-connected group carrying over its legacy flat tags,
+        // so LimitService::calculate() (which now reads tagGroups) keeps computing the same amounts.
+        $this->database()->execute("
+            INSERT INTO limit_tag_groups (limit_id, connection)
+            SELECT id, 'and' FROM limits
+        ");
+
+        $this->database()->execute('
+            INSERT INTO tag_limit_tag_groups (limit_tag_group_id, tag_id)
+            SELECT limit_tag_groups.id, tag_limits.tag_id
+            FROM tag_limits
+            INNER JOIN limit_tag_groups ON limit_tag_groups.limit_id = tag_limits.limit_id
+        ');
+    }
+
+    public function down(): void
+    {
+        $this->table('tag_limit_tag_groups')->drop();
+        $this->table('limit_tag_groups')->drop();
+    }
+}

--- a/app/src/Bootloader/CheckerBootloader.php
+++ b/app/src/Bootloader/CheckerBootloader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Bootloader;
 
 use App\Security\EncryptedEntityChecker;
+use App\Security\LimitTagGroupsChecker;
 use App\Security\PasswordChecker;
 use App\Security\UniqueChecker;
 use Spiral\Boot\Bootloader\Bootloader;
@@ -17,5 +18,6 @@ final class CheckerBootloader extends Bootloader
         $validation->addChecker('password', PasswordChecker::class);
         $validation->addChecker('unique', UniqueChecker::class);
         $validation->addChecker('encrypted-entity', EncryptedEntityChecker::class);
+        $validation->addChecker('limit-tag-groups', LimitTagGroupsChecker::class);
     }
 }

--- a/app/src/Controller/Wallets/Limits/LimitsController.php
+++ b/app/src/Controller/Wallets/Limits/LimitsController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Wallets\Limits;
 
 use App\Controller\Wallets\Controller;
 use App\Database\Limit;
+use App\Database\LimitTagGroup;
 use App\Database\Wallet;
 use App\Repository\LimitRepository;
 use App\Repository\TagRepository;
@@ -66,11 +67,7 @@ final class LimitsController extends Controller
         $limit->amount = $request->amount;
         $limit->setWallet($wallet);
 
-        $tags = $this->tagRepository->findAllByPKsAndUserPKs($request->tags, $wallet->getUserIDs());
-
-        foreach ($tags as $tag) {
-            $limit->tags->add($tag);
-        }
+        $this->attachTagGroups($limit, $request->tagGroups, $wallet->getUserIDs());
 
         try {
             $this->limitService->store($limit);
@@ -109,12 +106,8 @@ final class LimitsController extends Controller
         $limit->type = $request->type;
         $limit->amount = $request->amount;
 
-        $limit->tags->clear();
-        $tags = $this->tagRepository->findAllByPKsAndUserPKs($request->tags, $wallet->getUserIDs());
-
-        foreach ($tags as $tag) {
-            $limit->tags->add($tag);
-        }
+        $limit->tagGroups = [];
+        $this->attachTagGroups($limit, $request->tagGroups, $wallet->getUserIDs());
 
         try {
             $this->limitService->store($limit);
@@ -202,5 +195,26 @@ final class LimitsController extends Controller
         }
 
         return $this->walletLimitsView->json($limits);
+    }
+
+    /**
+     * @param array<array-key, array{operation: string, tags: array<array-key, int>}> $tagGroups
+     * @param array<array-key, int> $userIDs
+     */
+    private function attachTagGroups(Limit $limit, array $tagGroups, array $userIDs): void
+    {
+        foreach ($tagGroups as $group) {
+            $tagGroup = new LimitTagGroup();
+            $tagGroup->connection = $group['operation'] ?? LimitTagGroup::CONNECTION_OR;
+            $tagGroup->setLimit($limit);
+
+            $tags = $this->tagRepository->findAllByPKsAndUserPKs($group['tags'] ?? [], $userIDs);
+
+            foreach ($tags as $tag) {
+                $tagGroup->tags->add($tag);
+            }
+
+            $limit->tagGroups[] = $tagGroup;
+        }
     }
 }

--- a/app/src/Database/Limit.php
+++ b/app/src/Database/Limit.php
@@ -48,6 +48,12 @@ class Limit
     #[ORM\Relation\ManyToMany(target: Tag::class, through: TagLimit::class, collection: 'doctrine')]
     public PivotedCollection $tags;
 
+    /**
+     * @var array<int, \App\Database\LimitTagGroup>
+     */
+    #[ORM\Relation\HasMany(target: LimitTagGroup::class, outerKey: 'limit_id', collection: 'array')]
+    public array $tagGroups = [];
+
     public function __construct()
     {
         $this->wallet = new Wallet();
@@ -83,5 +89,23 @@ class Limit
         }
 
         return $tags;
+    }
+
+    /**
+     * @return array<int, \App\Database\LimitTagGroup>
+     */
+    public function getTagGroups(): array
+    {
+        $tagGroups = [];
+
+        foreach ($this->tagGroups as $tagGroup) {
+            if (! $tagGroup instanceof LimitTagGroup) {
+                continue;
+            }
+
+            $tagGroups[] = $tagGroup;
+        }
+
+        return $tagGroups;
     }
 }

--- a/app/src/Database/LimitTagGroup.php
+++ b/app/src/Database/LimitTagGroup.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Database;
+
+use Cycle\Annotated\Annotation as ORM;
+use Cycle\ORM\Collection\Pivoted\PivotedCollection;
+
+#[ORM\Entity]
+class LimitTagGroup
+{
+    const string CONNECTION_AND = 'and';
+    const string CONNECTION_OR  = 'or';
+
+    #[ORM\Column('primary')]
+    public int|null $id = null;
+
+    #[ORM\Column(type: 'int', name: 'limit_id')]
+    public int $limitId = 0;
+
+    #[ORM\Column(type: 'enum(and,or)', default: self::CONNECTION_OR)]
+    public string $connection = self::CONNECTION_OR;
+
+    #[ORM\Relation\BelongsTo(target: Limit::class, innerKey: 'limit_id', load: 'lazy')]
+    private Limit $limit;
+
+    /**
+     * @var \Cycle\ORM\Collection\Pivoted\PivotedCollection<int, \App\Database\Tag, \App\Database\TagLimitTagGroup>
+     */
+    #[ORM\Relation\ManyToMany(
+        target: Tag::class,
+        through: TagLimitTagGroup::class,
+        throughInnerKey: 'limit_tag_group_id',
+        throughOuterKey: 'tag_id',
+        collection: 'doctrine',
+    )]
+    public PivotedCollection $tags;
+
+    public function __construct()
+    {
+        $this->limit = new Limit();
+        $this->tags = new PivotedCollection();
+    }
+
+    public function getLimit(): Limit
+    {
+        return $this->limit;
+    }
+
+    public function setLimit(Limit $limit): void
+    {
+        $this->limit = $limit;
+        $this->limitId = (int) $limit->id;
+    }
+
+    /**
+     * @return array<int, \App\Database\Tag>
+     */
+    public function getTags(): array
+    {
+        $tags = [];
+
+        foreach ($this->tags->getValues() as $tag) {
+            if (! $tag instanceof Tag) {
+                continue;
+            }
+
+            $tags[] = $tag;
+        }
+
+        return $tags;
+    }
+}

--- a/app/src/Database/TagLimitTagGroup.php
+++ b/app/src/Database/TagLimitTagGroup.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Database;
+
+use Cycle\Annotated\Annotation as ORM;
+
+#[ORM\Entity]
+class TagLimitTagGroup
+{
+    #[ORM\Column('primary')]
+    public int|null $id = null;
+
+    #[ORM\Relation\BelongsTo(target: Tag::class, innerKey: 'tag_id', load: 'lazy')]
+    private Tag $tag;
+
+    #[ORM\Relation\BelongsTo(target: LimitTagGroup::class, innerKey: 'limit_tag_group_id', load: 'lazy')]
+    private LimitTagGroup $limitTagGroup;
+
+    public function __construct()
+    {
+        $this->tag = new Tag();
+        $this->limitTagGroup = new LimitTagGroup();
+    }
+}

--- a/app/src/Repository/ChargeRepository.php
+++ b/app/src/Repository/ChargeRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Database\LimitTagGroup;
 use App\Service\Filter\Filter;
 use Cycle\Database\Injection\Expression;
 use Cycle\Database\Injection\Fragment;
@@ -131,10 +132,16 @@ class ChargeRepository extends Repository
      * @param int $walletId
      * @param array<int, int> $tagIds
      * @param string|null $type
+     * @param string $connection LimitTagGroup::CONNECTION_AND requires a charge to carry every tag in $tagIds;
+     *                           LimitTagGroup::CONNECTION_OR requires only one of them.
      * @return float
      */
-    public function totalByWalletPKAndTagPKs(int $walletId, array $tagIds, ?string $type = null): float
-    {
+    public function totalByWalletPKAndTagPKs(
+        int $walletId,
+        array $tagIds,
+        ?string $type = null,
+        string $connection = LimitTagGroup::CONNECTION_AND,
+    ): float {
         /** @psalm-suppress InternalClass */
         $query = $this->select()->where('wallet_id', $walletId)->with('tags', [
             'method' => AbstractLoader::LEFT_JOIN,
@@ -153,8 +160,11 @@ class ChargeRepository extends Repository
 
         $query = $query->buildQuery()
                        ->columns([$chargesIdCol, $chargesAmountCol])
-                       ->groupBy($chargesIdCol)
-                       ->having(new Fragment("count(distinct {$tagsIdCol}) = ?", count($tagIds)));
+                       ->groupBy($chargesIdCol);
+
+        if ($connection === LimitTagGroup::CONNECTION_AND) {
+            $query = $query->having(new Fragment("count(distinct {$tagsIdCol}) = ?", count($tagIds)));
+        }
 
         return (float) $this->select()
                             ->buildQuery()

--- a/app/src/Repository/LimitRepository.php
+++ b/app/src/Repository/LimitRepository.php
@@ -19,7 +19,7 @@ class LimitRepository extends Repository
     public function findByPKByWalletPK(int $limitId, int $walletId)
     {
         return $this->select()
-                    ->load('tags')
+                    ->load('tagGroups.tags')
                     ->wherePK($limitId)
                     ->where('wallet_id', $walletId)
                     ->fetchOne();
@@ -32,7 +32,7 @@ class LimitRepository extends Repository
     public function findAllByWalletPK(int $walletId): array
     {
         return $this->select()
-                    ->load('tags')
+                    ->load('tagGroups.tags')
                     ->where('wallet_id', $walletId)
                     ->fetchAll();
     }

--- a/app/src/Request/Limit/CreateRequest.php
+++ b/app/src/Request/Limit/CreateRequest.php
@@ -23,10 +23,10 @@ class CreateRequest extends Filter implements HasFilterDefinition
     public float $amount = 0.0;
 
     /**
-     * @var array<array-key, int>
+     * @var array<array-key, array{operation: string, tags: array<array-key, int>}>
      */
     #[Data]
-    public array $tags = [];
+    public array $tagGroups = [];
 
     #[\Override]
     public function filterDefinition(): FilterDefinitionInterface
@@ -41,10 +41,10 @@ class CreateRequest extends Filter implements HasFilterDefinition
                 'type::notEmpty',
                 ['number::higher', 0]
             ],
-            'tags' => [
+            'tagGroups' => [
                 'type::notEmpty',
                 ['array::longer', 0],
-                ['array::of', ['entity:exists', Tag::class, 'id']],
+                ['limit-tag-groups::valid', Tag::class],
             ],
         ]);
     }

--- a/app/src/Security/LimitTagGroupsChecker.php
+++ b/app/src/Security/LimitTagGroupsChecker.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Database\LimitTagGroup;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Select\Repository;
+use Spiral\Core\Attribute\Singleton;
+use Spiral\Validator\AbstractChecker;
+
+/**
+ * Validates the `tagGroups` request shape: array<{operation: 'and'|'or', tags: int[]}>.
+ * Mirrors `array::of` + `entity:exists` (multiple mode), one structural level deeper.
+ */
+#[Singleton]
+final class LimitTagGroupsChecker extends AbstractChecker
+{
+    public const array MESSAGES = [
+        'valid' => 'error_limit_tag_groups_invalid',
+    ];
+
+    public function __construct(
+        private readonly ORMInterface $orm,
+    ) {
+    }
+
+    public function valid(mixed $value, string $role): bool
+    {
+        if (!is_array($value) || empty($value) || empty($role)) {
+            return false;
+        }
+
+        $repository = $this->orm->getRepository($role);
+
+        if (!$repository instanceof Repository) {
+            return false;
+        }
+
+        foreach ($value as $group) {
+            if (!$this->validGroup($group, $repository)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function validGroup(mixed $group, Repository $repository): bool
+    {
+        if (!is_array($group)) {
+            return false;
+        }
+
+        $operation = $group['operation'] ?? null;
+
+        if (
+            !is_string($operation)
+            || !in_array($operation, [LimitTagGroup::CONNECTION_AND, LimitTagGroup::CONNECTION_OR], true)
+        ) {
+            return false;
+        }
+
+        $tagIds = $group['tags'] ?? null;
+
+        if (!is_array($tagIds) || empty($tagIds)) {
+            return false;
+        }
+
+        foreach ($tagIds as $tagId) {
+            if (!is_int($tagId) && !(is_string($tagId) && ctype_digit($tagId))) {
+                return false;
+            }
+        }
+
+        return $repository->select()->wherePK(...$tagIds)->count() === count($tagIds);
+    }
+}

--- a/app/src/Service/Limit/LimitService.php
+++ b/app/src/Service/Limit/LimitService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\Limit;
 
 use App\Database\Limit;
+use App\Database\LimitTagGroup;
 use App\Database\Tag;
 use App\Database\Wallet;
 use App\Repository\ChargeRepository;
@@ -31,20 +32,33 @@ class LimitService
         // TODO. Aggregate all limits using 1 query
 
         foreach ($limits as $limit) {
-            $tagIds = array_map(fn (Tag $tag) => (int) $tag->id, $limit->getTags());
+            $limitAmount = 0.0;
+            $correctionAmount = 0.0;
 
-            $limitAmount = $this->chargeRepository->totalByWalletPKAndTagPKs(
-                $limit->walletId,
-                $tagIds,
-                $limit->type
-            );
+            // Each group's amount is summed literally: charges matched by more than one
+            // group are counted again for every group they match, by design.
+            foreach ($limit->getTagGroups() as $tagGroup) {
+                $tagIds = array_map(fn (Tag $tag) => (int) $tag->id, $tagGroup->getTags());
 
-            // calculate total for opposite limit type to get the correction amount
-            $correctionAmount = $this->chargeRepository->totalByWalletPKAndTagPKs(
-                $limit->walletId,
-                $tagIds,
-                $limit->type == Limit::TYPE_INCOME ? Limit::TYPE_EXPENSE : Limit::TYPE_INCOME,
-            );
+                if ($tagIds === []) {
+                    continue;
+                }
+
+                $limitAmount += $this->chargeRepository->totalByWalletPKAndTagPKs(
+                    $limit->walletId,
+                    $tagIds,
+                    $limit->type,
+                    $tagGroup->connection,
+                );
+
+                // calculate total for opposite limit type to get the correction amount
+                $correctionAmount += $this->chargeRepository->totalByWalletPKAndTagPKs(
+                    $limit->walletId,
+                    $tagIds,
+                    $limit->type == Limit::TYPE_INCOME ? Limit::TYPE_EXPENSE : Limit::TYPE_INCOME,
+                    $tagGroup->connection,
+                );
+            }
 
             $amount = 0;
 
@@ -71,6 +85,7 @@ class LimitService
     {
         $sourceLimits = $this->limitRepository->findAllByWalletPK((int) $source->id);
 
+        $limits = [];
         $list = [];
 
         foreach ($sourceLimits as $sourceLimit) {
@@ -81,13 +96,25 @@ class LimitService
             $limit->amount = $sourceLimit->amount;
             $limit->setWallet($target);
 
-            foreach ($sourceLimit->tags as $tag) {
-                $limit->tags->add($tag);
+            foreach ($sourceLimit->getTagGroups() as $sourceTagGroup) {
+                $tagGroup = new LimitTagGroup();
+                $tagGroup->connection = $sourceTagGroup->connection;
+                $tagGroup->setLimit($limit);
+
+                foreach ($sourceTagGroup->getTags() as $tag) {
+                    $tagGroup->tags->add($tag);
+                }
+
+                $limit->tagGroups[] = $tagGroup;
             }
 
-            $this->tr->persist($limit);
+            $limits[] = $limit;
 
             $list[] = new WalletLimit($limit, 0);
+        }
+
+        foreach ($limits as $limit) {
+            $this->tr->persist($limit);
         }
 
         $this->tr->run();

--- a/app/src/View/LimitTagGroupView.php
+++ b/app/src/View/LimitTagGroupView.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\View;
+
+use App\Database\LimitTagGroup;
+use Psr\Http\Message\ResponseInterface;
+use Spiral\Core\Attribute\Singleton;
+use Spiral\Http\ResponseWrapper;
+
+#[Singleton]
+final class LimitTagGroupView
+{
+    public function __construct(
+        protected ResponseWrapper $response,
+        protected TagsView $tagsView,
+    ) {
+    }
+
+    /**
+     * @param array<array-key, LimitTagGroup> $tagGroups
+     */
+    public function json(array $tagGroups): ResponseInterface
+    {
+        return $this->response->json([
+            'data' => $this->map($tagGroups),
+        ]);
+    }
+
+    /**
+     * @param array<array-key, LimitTagGroup> $tagGroups
+     */
+    public function map(array $tagGroups): array
+    {
+        return array_map([$this, 'mapOne'], $tagGroups);
+    }
+
+    private function mapOne(LimitTagGroup $tagGroup): array
+    {
+        return [
+            'type'       => 'limitTagGroup',
+            'connection' => $tagGroup->connection,
+            'tags'       => $this->tagsView->map($tagGroup->getTags()),
+        ];
+    }
+}

--- a/app/src/View/LimitView.php
+++ b/app/src/View/LimitView.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\View;
 
 use App\Database\Limit;
-use App\Database\Tag;
 use App\Database\Wallet;
 use Psr\Http\Message\ResponseInterface;
 use Spiral\Core\Attribute\Singleton;
@@ -18,10 +17,9 @@ final class LimitView
 
     public function __construct(
         protected ResponseWrapper $response,
-        protected TagsView $tagsView,
+        protected LimitTagGroupView $limitTagGroupView,
         protected WalletShortView $walletShortView,
     ) {
-        $this->withRelations([Tag::class]);
     }
 
     public function json(Limit $limit): ResponseInterface
@@ -46,7 +44,8 @@ final class LimitView
             'createdAt'   => $limit->createdAt->format(DATE_W3C),
             'updatedAt'   => $limit->updatedAt->format(DATE_W3C),
 
-            'tags'        => $this->loaded(Tag::class) ? $this->tagsView->map($limit->getTags()) : [],
+            'tags'        => [],
+            'tagGroups'   => $this->limitTagGroupView->map($limit->getTagGroups()),
             'wallet'      => $this->loaded(Wallet::class) ? $this->walletShortView->map($limit->getWallet()) : null,
         ];
     }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1596,9 +1596,9 @@ paths:
       operationId: limitCreate
       summary: Create a budget limit
       description: |
-        Creates a new budget limit for a set of tags within a wallet.
-        Requires at least one tag. The limit fires when charges matching the
-        given tags exceed `amount`.
+        Creates a new budget limit for a wallet from one or more tag groups.
+        Requires at least one tag group. The limit fires when the summed
+        charges matching each group's tags exceed `amount`.
       tags: [Limits]
       security:
         - bearerAuth: []
@@ -2883,9 +2883,35 @@ components:
     # -----------------------------------------------------------------------
     # LIMIT
     # -----------------------------------------------------------------------
+    LimitTagGroup:
+      type: object
+      description: |
+        A group of tags within a limit. Charges are matched against each group
+        independently using its `connection` (`and` requires every tag in the
+        group to be present on a charge, `or` requires any one of them); the
+        limit's totals are the sum across all its groups, without deduplicating
+        charges matched by more than one group.
+      required:
+        - type
+        - connection
+        - tags
+      properties:
+        type:
+          type: string
+          enum: [limitTagGroup]
+          readOnly: true
+        connection:
+          type: string
+          enum: ["and", "or"]
+          description: How this group's tags are matched against a charge's tags
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tag"
+
     Limit:
       type: object
-      description: A budget ceiling for charges matching a set of tags in a wallet.
+      description: A budget ceiling for charges matching a set of tag groups in a wallet.
       required:
         - type
         - id
@@ -2895,6 +2921,7 @@ components:
         - createdAt
         - updatedAt
         - tags
+        - tagGroups
       properties:
         type:
           type: string
@@ -2925,6 +2952,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Tag"
+          deprecated: true
+          description: Deprecated, always empty. Use `tagGroups` instead.
+        tagGroups:
+          type: array
+          items:
+            $ref: "#/components/schemas/LimitTagGroup"
         wallet:
           $ref: "#/components/schemas/WalletShort"
 
@@ -2948,12 +2981,29 @@ components:
         limit:
           $ref: "#/components/schemas/Limit"
 
+    CreateLimitTagGroupRequest:
+      type: object
+      required:
+        - operation
+        - tags
+      properties:
+        operation:
+          type: string
+          enum: ["and", "or"]
+          description: How this group's tags are matched against a charge's tags
+        tags:
+          type: array
+          minItems: 1
+          items:
+            type: integer
+          description: Tag IDs in this group (min 1)
+
     CreateLimitRequest:
       type: object
       required:
         - type
         - amount
-        - tags
+        - tagGroups
       properties:
         type:
           type: string
@@ -2965,10 +3015,19 @@ components:
           minimum: 0.01
         tags:
           type: array
-          minItems: 1
           items:
             type: integer
-          description: Tag IDs that this limit applies to (min 1)
+          deprecated: true
+          description: Deprecated and ignored. Use `tagGroups` instead.
+        tagGroups:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/CreateLimitTagGroupRequest"
+          description: |
+            Tag groups this limit applies to (min 1). Each group's tags are
+            matched using its own `operation`; totals are summed across groups
+            without deduplicating charges matched by more than one group.
 
     # -----------------------------------------------------------------------
     # CURRENCY

--- a/tests/Factories/LimitFactory.php
+++ b/tests/Factories/LimitFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Factories;
 
 use App\Database\Limit;
+use App\Database\LimitTagGroup;
 use App\Database\Wallet;
 use Doctrine\Common\Collections\ArrayCollection;
 use Tests\Fixtures;
@@ -18,6 +19,11 @@ class LimitFactory extends AbstractFactory
      */
     protected array $tags = [];
 
+    /**
+     * @var array<array-key, array{connection?: string, tags?: array<array-key, \App\Database\Tag>}>
+     */
+    protected array $tagGroups = [];
+
     public function forWallet(?Wallet $wallet = null): LimitFactory
     {
         $this->wallet = $wallet;
@@ -28,6 +34,16 @@ class LimitFactory extends AbstractFactory
     public function withTags(array $tags = []): LimitFactory
     {
         $this->tags = $tags;
+
+        return $this;
+    }
+
+    /**
+     * @param array<array-key, array{connection?: string, tags?: array<array-key, \App\Database\Tag>}> $tagGroups
+     */
+    public function withTagGroups(array $tagGroups = []): LimitFactory
+    {
+        $this->tagGroups = $tagGroups;
 
         return $this;
     }
@@ -65,6 +81,18 @@ class LimitFactory extends AbstractFactory
             $limit->tags->add($tag);
         }
 
+        foreach ($this->tagGroups as $group) {
+            $tagGroup = new LimitTagGroup();
+            $tagGroup->connection = $group['connection'] ?? LimitTagGroup::CONNECTION_OR;
+            $tagGroup->setLimit($limit);
+
+            foreach ($group['tags'] ?? [] as $tag) {
+                $tagGroup->tags->add($tag);
+            }
+
+            $limit->tagGroups[] = $tagGroup;
+        }
+
         $this->persist($limit);
 
         return $limit;
@@ -87,15 +115,15 @@ class LimitFactory extends AbstractFactory
 
     public static function income(?Limit $limit = null): Limit
     {
-        return self::type($limit, Limit::TYPE_INCOME);
+        return self::type(Limit::TYPE_INCOME, $limit);
     }
 
     public static function expense(?Limit $limit = null): Limit
     {
-        return self::type($limit, Limit::TYPE_EXPENSE);
+        return self::type(Limit::TYPE_EXPENSE, $limit);
     }
 
-    public static function type(?Limit $limit = null, string $type): Limit
+    public static function type(string $type, ?Limit $limit = null): Limit
     {
         if ($limit === null) {
             $limit = self::make();

--- a/tests/Feature/Controller/Wallets/Limits/LimitsControllerTest.php
+++ b/tests/Feature/Controller/Wallets/Limits/LimitsControllerTest.php
@@ -229,6 +229,36 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $this->assertEquals((string) $expected, (string) $body['data'][0]['amount']);
     }
 
+    public function testListReturnLimitsSkipsEmptyTagGroups(): void
+    {
+        $auth = $this->makeAuth($user = $this->userFactory->create());
+        $wallet = $this->walletFactory->forUser($user)->create();
+
+        $tag = $this->tagFactory->forUser($user)->create();
+
+        $charge = ChargeFactory::expense();
+        $charge->amount = 20.0;
+        $this->chargeFactory->forUser($user)->forWallet($wallet)->withTags([$tag])->create($charge);
+
+        // A group with no tags (not reachable through the API's validation, but possible
+        // for pre-existing data) must be skipped rather than break the calculation.
+        $this->limitFactory->forWallet($wallet)
+            ->withTagGroups([
+                ['connection' => LimitTagGroup::CONNECTION_AND, 'tags' => [$tag]],
+                ['connection' => LimitTagGroup::CONNECTION_OR, 'tags' => []],
+            ])
+            ->create(LimitFactory::expense());
+
+        $response = $this->withAuth($auth)->get("/wallets/{$wallet->id}/limits");
+
+        $response->assertOk();
+
+        $body = $this->getJsonResponseBody($response);
+
+        $this->assertCount(1, $body['data']);
+        $this->assertEquals((string) $charge->amount, (string) $body['data'][0]['amount']);
+    }
+
     public function testCreateRequireAuth(): void
     {
         $wallet = $this->walletFactory->create();

--- a/tests/Feature/Controller/Wallets/Limits/LimitsControllerTest.php
+++ b/tests/Feature/Controller/Wallets/Limits/LimitsControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Controller\Wallets\Limits;
 
+use App\Database\LimitTagGroup;
 use App\Service\Limit\LimitService;
 use PHPUnit\Framework\MockObject\MockObject;
 use Tests\DatabaseTransaction;
@@ -36,6 +37,24 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $this->limitFactory = $this->getContainer()->get(LimitFactory::class);
         $this->tagFactory = $this->getContainer()->get(TagFactory::class);
         $this->chargeFactory = $this->getContainer()->get(ChargeFactory::class);
+    }
+
+    /**
+     * Fetches the `limit_tag_group_id` of the (only) group created for a limit and
+     * asserts the pivot row linking it to $tagId exists.
+     */
+    protected function assertTagGroupHasTag(int $limitId, int $tagId): void
+    {
+        $groups = $this->queryDatabase('limit_tag_groups', ['limit_id' => $limitId]);
+
+        $this->assertNotEmpty($groups, "No limit_tag_groups row found for limit {$limitId}");
+
+        $groupIds = array_column($groups, 'id');
+
+        $this->assertDatabaseHas('tag_limit_tag_groups', [
+            'limit_tag_group_id' => ['in' => $groupIds],
+            'tag_id' => $tagId,
+        ]);
     }
 
     public function testListRequireAuth(): void
@@ -102,11 +121,15 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $this->chargeFactory->forUser($user)->forWallet($wallet)->createMany(4);
 
         $tag = $this->tagFactory->forUser($user)->create();
-        $limit = $this->limitFactory->forWallet($wallet)->withTags([$tag])->create();
+        $limit = $this->limitFactory->forWallet($wallet)->withTagGroups([
+            ['connection' => LimitTagGroup::CONNECTION_AND, 'tags' => [$tag]],
+        ])->create();
         $charges = $this->chargeFactory->forUser($user)->forWallet($wallet)->withTags([$tag])->createMany(4);
 
         $tags = $this->tagFactory->forUser($user)->createMany(2);
-        $limitWithTwoTags = $this->limitFactory->forWallet($wallet)->withTags($tags->toArray())->create();
+        $limitWithTwoTags = $this->limitFactory->forWallet($wallet)->withTagGroups([
+            ['connection' => LimitTagGroup::CONNECTION_AND, 'tags' => $tags->toArray()],
+        ])->create();
         $chargesWithTwoTags = $this->chargeFactory->forUser($user)->forWallet($wallet)->withTags($tags->toArray())->createMany(4);
 
         $chargesTotal = 0;
@@ -153,20 +176,57 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         foreach ($body['data'] as $limitData) {
             $this->assertArrayHasKey('limit', $limitData);
             $this->assertArrayHasKey('amount', $limitData['limit']);
+            $this->assertEquals([], $limitData['limit']['tags']);
+
             if ((string) $limitData['limit']['amount'] === (string) $limit->amount) {
                 $this->assertEquals((string) $chargesTotal, (string) ($limitData['amount'] ?? null));
                 $this->assertEquals($limit->type, $limitData['limit']['operation'] ?? null);
                 $this->assertEquals($limit->amount, $limitData['limit']['amount'] ?? null);
-                $this->assertArrayContains($tag->id, $limitData['limit']['tags'], '*.id');
+                $this->assertArrayContains($tag->id, $limitData['limit']['tagGroups'], '*.tags.*.id');
             } else {
                 $this->assertEquals((string) $chargesWithTwoTagsTotal, (string) $limitData['amount']);
                 $this->assertEquals($limitWithTwoTags->type, $limitData['limit']['operation'] ?? null);
                 $this->assertEquals($limitWithTwoTags->amount, $limitData['limit']['amount'] ?? null);
                 foreach ($tags as $item) {
-                    $this->assertArrayContains($item->id, $limitData['limit']['tags'], '*.id');
+                    $this->assertArrayContains($item->id, $limitData['limit']['tagGroups'], '*.tags.*.id');
                 }
             }
         }
+    }
+
+    public function testListReturnLimitsSumsAcrossGroupsWithoutDedup(): void
+    {
+        $auth = $this->makeAuth($user = $this->userFactory->create());
+        $wallet = $this->walletFactory->forUser($user)->create();
+
+        $tagA = $this->tagFactory->forUser($user)->create();
+        $tagB = $this->tagFactory->forUser($user)->create();
+
+        // Charge matches both group A ([tagA], AND) and group B ([tagB], OR).
+        $charge = ChargeFactory::expense();
+        $charge->amount = 42.5;
+        $sharedCharge = $this->chargeFactory->forUser($user)->forWallet($wallet)
+            ->withTags([$tagA, $tagB])
+            ->create($charge);
+
+        $this->limitFactory->forWallet($wallet)
+            ->withTagGroups([
+                ['connection' => LimitTagGroup::CONNECTION_AND, 'tags' => [$tagA]],
+                ['connection' => LimitTagGroup::CONNECTION_OR, 'tags' => [$tagB]],
+            ])
+            ->create(LimitFactory::expense());
+
+        $response = $this->withAuth($auth)->get("/wallets/{$wallet->id}/limits");
+
+        $response->assertOk();
+
+        $body = $this->getJsonResponseBody($response);
+
+        $this->assertCount(1, $body['data']);
+
+        // The shared charge matches both groups, so it must be counted twice (no dedup).
+        $expected = round($sharedCharge->amount * 2, 2);
+        $this->assertEquals((string) $expected, (string) $body['data'][0]['amount']);
     }
 
     public function testCreateRequireAuth(): void
@@ -178,7 +238,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->post("/wallets/{$wallet->id}/limits", [
             'type' => $limit->type,
             'amount' => $limit->amount,
-            'tags' => null,
+            'tagGroups' => null,
         ]);
 
         $response->assertUnauthorized();
@@ -193,7 +253,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->post("/wallets/{$walletId}/limits", [
             'type' => $limit->type,
             'amount' => $limit->amount,
-            'tags' => null,
+            'tagGroups' => null,
         ]);
 
         $response->assertUnauthorized();
@@ -211,7 +271,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->post("/wallets/{$walletId}/limits", [
             'type' => $limit->type,
             'amount' => $limit->amount,
-            'tags' => [$tag->id],
+            'tagGroups' => [['operation' => 'and', 'tags' => [$tag->id]]],
         ]);
 
         $response->assertNotFound();
@@ -229,7 +289,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->post("/wallets/{$wallet->id}/limits", [
             'type' => $limit->type,
             'amount' => $limit->amount,
-            'tags' => [$tag->id],
+            'tagGroups' => [['operation' => 'and', 'tags' => [$tag->id]]],
         ]);
 
         $response->assertNotFound();
@@ -238,22 +298,27 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
     public function createValidationFailsDataProvider(): array
     {
         return [
-            [[], ['type', 'amount', 'tags']],
+            [[], ['type', 'amount', 'tagGroups']],
             [[
                 'type' => 'W',
                 'amount' => 'false',
-                'tags' => false,
-            ], ['type', 'amount', 'tags',]],
+                'tagGroups' => false,
+            ], ['type', 'amount', 'tagGroups']],
             [[
                 'type' => '+',
                 'amount' => 0,
-                'tags' => [],
-            ], ['amount', 'tags']],
+                'tagGroups' => [],
+            ], ['amount', 'tagGroups']],
             [[
                 'type' => '+',
                 'amount' => -1,
-                'tags' => [-1],
-            ], ['amount', 'tags']],
+                'tagGroups' => [['operation' => 'and', 'tags' => [-1]]],
+            ], ['amount', 'tagGroups']],
+            [[
+                'type' => '+',
+                'amount' => 1,
+                'tagGroups' => [['operation' => 'xor', 'tags' => [-1]]],
+            ], ['tagGroups']],
         ];
     }
 
@@ -294,7 +359,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->post("/wallets/{$wallet->id}/limits", [
             'type' => $limit->type,
             'amount' => $limit->amount,
-            'tags' => $tags->map(fn($tag) => $tag->id)->toArray(),
+            'tagGroups' => [['operation' => 'and', 'tags' => $tags->map(fn($tag) => $tag->id)->toArray()]],
         ]);
 
         $response->assertOk();
@@ -304,6 +369,9 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $this->assertArrayHasKey('id', $body['data']);
         $this->assertArrayContains($limit->type, $body, 'data.operation');
         $this->assertArrayContains($limit->amount, $body, 'data.amount');
+        $this->assertEquals([], $body['data']['tags']);
+        $this->assertCount(1, $body['data']['tagGroups']);
+        $this->assertEquals('and', $body['data']['tagGroups'][0]['connection']);
 
         $this->assertDatabaseHas('limits', [
             'type' => $limit->type,
@@ -311,12 +379,51 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
             'wallet_id' => $wallet->id,
         ]);
 
+        $this->assertDatabaseHas('limit_tag_groups', [
+            'limit_id' => $body['data']['id'],
+            'connection' => 'and',
+        ]);
+
         foreach ($tags as $tag) {
-            $this->assertDatabaseHas('tag_limits', [
-                'tag_id' => $tag->id,
-                'limit_id' => $body['data']['id'],
-            ]);
+            $this->assertTagGroupHasTag((int) $body['data']['id'], (int) $tag->id);
         }
+    }
+
+    public function testCreateStoreLimitWithMultipleTagGroups(): void
+    {
+        $auth = $this->makeAuth($user = $this->userFactory->create());
+
+        $wallet = $this->walletFactory->forUser($user)->create();
+
+        $limit = LimitFactory::make();
+        $tagA = $this->tagFactory->forUser($user)->create();
+        $tagB = $this->tagFactory->forUser($user)->create();
+        $tagC = $this->tagFactory->forUser($user)->create();
+
+        $response = $this->withAuth($auth)->post("/wallets/{$wallet->id}/limits", [
+            'type' => $limit->type,
+            'amount' => $limit->amount,
+            'tagGroups' => [
+                ['operation' => 'and', 'tags' => [$tagA->id]],
+                ['operation' => 'or', 'tags' => [$tagB->id, $tagC->id]],
+            ],
+        ]);
+
+        $response->assertOk();
+
+        $body = $this->getJsonResponseBody($response);
+
+        $this->assertCount(2, $body['data']['tagGroups']);
+
+        $connections = array_map(fn($group) => $group['connection'], $body['data']['tagGroups']);
+        sort($connections);
+        $this->assertEquals(['and', 'or'], $connections);
+
+        $this->assertArrayContains($tagA->id, $body['data']['tagGroups'], '*.tags.*.id');
+        $this->assertArrayContains($tagB->id, $body['data']['tagGroups'], '*.tags.*.id');
+        $this->assertArrayContains($tagC->id, $body['data']['tagGroups'], '*.tags.*.id');
+
+        $this->assertDatabaseCount(2, 'limit_tag_groups', ['limit_id' => $body['data']['id']]);
     }
 
     public function testCreateThrownException(): void
@@ -335,7 +442,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->post("/wallets/{$wallet->id}/limits", [
             'type' => $limit->type,
             'amount' => $limit->amount,
-            'tags' => $tags->map(fn($tag) => $tag->id)->toArray(),
+            'tagGroups' => [['operation' => 'and', 'tags' => $tags->map(fn($tag) => $tag->id)->toArray()]],
         ]);
 
         $response->assertStatus(500);
@@ -404,7 +511,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->put("/wallets/{$walletId}/limits/{$limitId}", [
             'type' => $updatedLimit->type,
             'amount' => $updatedLimit->amount,
-            'tags' => [$tag->id],
+            'tagGroups' => [['operation' => 'and', 'tags' => [$tag->id]]],
         ]);
 
         $response->assertNotFound();
@@ -422,7 +529,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->put("/wallets/{$wallet->id}/limits/{$limitId}", [
             'type' => $updatedLimit->type,
             'amount' => $updatedLimit->amount,
-            'tags' => [$tag->id],
+            'tagGroups' => [['operation' => 'and', 'tags' => [$tag->id]]],
         ]);
 
         $response->assertNotFound();
@@ -440,7 +547,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->put("/wallets/{$wallet->id}/limits/{$limit->id}", [
             'type' => $updatedLimit->type,
             'amount' => $updatedLimit->amount,
-            'tags' => [$tag->id],
+            'tagGroups' => [['operation' => 'and', 'tags' => [$tag->id]]],
         ]);
 
         $response->assertNotFound();
@@ -449,22 +556,22 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
     public function updateValidationFailsDataProvider(): array
     {
         return [
-            [[], ['type', 'amount', 'tags']],
+            [[], ['type', 'amount', 'tagGroups']],
             [[
                 'type' => 'W',
                 'amount' => 'false',
-                'tags' => '',
-            ], ['type', 'amount', 'tags']],
+                'tagGroups' => '',
+            ], ['type', 'amount', 'tagGroups']],
             [[
                 'type' => '+',
                 'amount' => 0,
-                'tags' => [],
-            ], ['amount', 'tags']],
+                'tagGroups' => [],
+            ], ['amount', 'tagGroups']],
             [[
                 'type' => '+',
                 'amount' => -1,
-                'tags' => [-1],
-            ], ['amount', 'tags']],
+                'tagGroups' => [['operation' => 'and', 'tags' => [-1]]],
+            ], ['amount', 'tagGroups']],
         ];
     }
 
@@ -503,7 +610,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->post("/wallets/{$wallet->id}/limits", [
             'type' => $limit->type,
             'amount' => $limit->amount,
-            'tags' => [$tag->id],
+            'tagGroups' => [['operation' => 'and', 'tags' => [$tag->id]]],
         ]);
 
         $response->assertOk();
@@ -516,17 +623,16 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->put("/wallets/{$wallet->id}/limits/{$limitId}", [
             'type' => $updatedLimit->type,
             'amount' => $updatedLimit->amount,
-            'tags' => [$updatedTag->id],
+            'tagGroups' => [['operation' => 'or', 'tags' => [$updatedTag->id]]],
         ]);
 
         $response->assertOk();
 
         $body = $this->getJsonResponseBody($response);
 
-
         $this->assertArrayContains($updatedLimit->type, $body, 'data.operation');
         $this->assertArrayContains($updatedLimit->amount, $body, 'data.amount');
-        $this->assertArrayContains($updatedTag->id, $body, 'data.tags.*.id');
+        $this->assertArrayContains($updatedTag->id, $body, 'data.tagGroups.*.tags.*.id');
 
         $this->assertDatabaseHas('limits', [
             'type' => $updatedLimit->type,
@@ -534,10 +640,15 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
             'wallet_id' => $wallet->id,
         ]);
 
-        $this->assertDatabaseHas('tag_limits', [
-            'tag_id' => $updatedTag->id,
+        $this->assertDatabaseHas('limit_tag_groups', [
             'limit_id' => $limitId,
+            'connection' => 'or',
         ]);
+        $this->assertTagGroupHasTag((int) $limitId, (int) $updatedTag->id);
+
+        // Old group's tag must no longer be attached to this limit.
+        $oldGroups = $this->queryDatabase('limit_tag_groups', ['limit_id' => $limitId]);
+        $this->assertCount(1, $oldGroups);
     }
 
     public function testUpdateThrownException(): void
@@ -557,7 +668,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->put("/wallets/{$wallet->id}/limits/{$limit->id}", [
             'type' => $updatedLimit->type,
             'amount' => $updatedLimit->amount,
-            'tags' => [$tag->id],
+            'tagGroups' => [['operation' => 'and', 'tags' => [$tag->id]]],
         ]);
 
         $response->assertStatus(500);
@@ -642,7 +753,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
         $response = $this->withAuth($auth)->post("/wallets/{$wallet->id}/limits", [
             'type' => $limit->type,
             'amount' => $limit->amount,
-            'tags' => [$tag->id],
+            'tagGroups' => [['operation' => 'and', 'tags' => [$tag->id]]],
         ]);
 
         $response->assertOk();
@@ -659,8 +770,7 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
             'wallet_id' => $wallet->id,
         ]);
 
-        $this->assertDatabaseMissing('tag_limits', [
-            'tag_id' => $tag->id,
+        $this->assertDatabaseMissing('limit_tag_groups', [
             'limit_id' => $limitId,
         ]);
 
@@ -753,7 +863,9 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
 
         $sourceWallet = $this->walletFactory->forUser($user)->create();
         $tags = $this->tagFactory->forUser($user)->createMany(2);
-        $limits = $this->limitFactory->forWallet($sourceWallet)->withTags($tags->toArray())->createMany(2);
+        $limits = $this->limitFactory->forWallet($sourceWallet)->withTagGroups([
+            ['connection' => LimitTagGroup::CONNECTION_AND, 'tags' => $tags->toArray()],
+        ])->createMany(2);
 
         $response = $this->withAuth($auth)->post("/wallets/{$wallet->id}/limits/copy/{$sourceWallet->id}");
 
@@ -771,10 +883,11 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
             $this->assertArrayContains($limit->amount, $body, 'data.*.limit.amount');
             $this->assertArrayContains($wallet->id, $body, 'data.*.limit.walletId');
 
-            $this->assertArrayHasKey('tags', $body['data'][$i]['limit']);
-            $this->assertCount(count($limits), $body['data'][$i]['limit']['tags']);
+            $this->assertArrayHasKey('tagGroups', $body['data'][$i]['limit']);
+            $this->assertCount(1, $body['data'][$i]['limit']['tagGroups']);
+            $this->assertCount(count($tags), $body['data'][$i]['limit']['tagGroups'][0]['tags']);
             foreach ($tags as $tag) {
-                $this->assertArrayContains($tag->id, $body['data'][$i], 'limit.tags.*.id');
+                $this->assertArrayContains($tag->id, $body['data'][$i]['limit']['tagGroups'], '*.tags.*.id');
             }
         }
     }
@@ -787,7 +900,9 @@ class LimitsControllerTest extends TestCase implements DatabaseTransaction
 
         $sourceWallet = $this->walletFactory->forUser($user)->create();
         $tags = $this->tagFactory->forUser($user)->createMany(2);
-        $this->limitFactory->forWallet($sourceWallet)->withTags($tags->toArray())->createMany(2);
+        $this->limitFactory->forWallet($sourceWallet)->withTagGroups([
+            ['connection' => LimitTagGroup::CONNECTION_AND, 'tags' => $tags->toArray()],
+        ])->createMany(2);
 
         $this->mock(LimitService::class, ['copy'], function (MockObject $mock) {
             $mock->expects($this->once())->method('copy')->willThrowException(new \RuntimeException());

--- a/tests/Feature/Database/LimitTagGroupTest.php
+++ b/tests/Feature/Database/LimitTagGroupTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Database;
+
+use App\Database\Limit;
+use App\Database\LimitTagGroup;
+use Tests\TestCase;
+
+class LimitTagGroupTest extends TestCase
+{
+    public function testCreateEntity(): void
+    {
+        $entity = new LimitTagGroup();
+
+        $this->assertNotNull($entity);
+    }
+
+    public function testGetSetLimit(): void
+    {
+        $tagGroup = new LimitTagGroup();
+        $limit = new Limit();
+        $limit->id = 5;
+
+        $tagGroup->setLimit($limit);
+
+        $this->assertSame($limit, $tagGroup->getLimit());
+        $this->assertSame(5, $tagGroup->limitId);
+    }
+
+    public function testGetTagsVerifyType(): void
+    {
+        $tagGroup = new LimitTagGroup();
+        $tagGroup->tags->add(null);
+
+        $this->assertCount(0, $tagGroup->getTags());
+    }
+}

--- a/tests/Feature/Database/LimitTest.php
+++ b/tests/Feature/Database/LimitTest.php
@@ -29,4 +29,12 @@ class LimitTest extends TestCase
 
         $this->assertCount(0, $limit->getTags());
     }
+
+    public function testGetTagGroupsVerifyType(): void
+    {
+        $limit = new Limit();
+        $limit->tagGroups[] = null;
+
+        $this->assertCount(0, $limit->getTagGroups());
+    }
 }

--- a/tests/Feature/Database/TagLimitTagGroupTest.php
+++ b/tests/Feature/Database/TagLimitTagGroupTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Database;
+
+use App\Database\TagLimitTagGroup;
+use Tests\TestCase;
+
+class TagLimitTagGroupTest extends TestCase
+{
+    public function testCreateEntity(): void
+    {
+        $entity = new TagLimitTagGroup();
+
+        $this->assertNotNull($entity);
+    }
+}

--- a/tests/Feature/Security/LimitTagGroupsCheckerTest.php
+++ b/tests/Feature/Security/LimitTagGroupsCheckerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Database\LimitTagGroup;
+use App\Database\Tag;
+use App\Security\LimitTagGroupsChecker;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\RepositoryInterface;
+use Tests\TestCase;
+
+class LimitTagGroupsCheckerTest extends TestCase
+{
+    public function testValidNonArrayValue(): void
+    {
+        $checker = new LimitTagGroupsChecker($this->getContainer()->get(ORMInterface::class));
+
+        $this->assertFalse($checker->valid('not-an-array', Tag::class));
+    }
+
+    public function testValidEmptyRole(): void
+    {
+        $checker = new LimitTagGroupsChecker($this->getContainer()->get(ORMInterface::class));
+
+        $this->assertFalse($checker->valid([
+            ['operation' => LimitTagGroup::CONNECTION_AND, 'tags' => [1]],
+        ], ''));
+    }
+
+    public function testValidRepositoryNotSelectRepository(): void
+    {
+        $orm = $this->getMockBuilder(ORMInterface::class)->getMock();
+        $orm->method('getRepository')->willReturn(
+            $this->getMockBuilder(RepositoryInterface::class)->getMock()
+        );
+
+        $checker = new LimitTagGroupsChecker($orm);
+
+        $this->assertFalse($checker->valid([
+            ['operation' => LimitTagGroup::CONNECTION_AND, 'tags' => [1]],
+        ], Tag::class));
+    }
+
+    public function testValidGroupNotArray(): void
+    {
+        $checker = new LimitTagGroupsChecker($this->getContainer()->get(ORMInterface::class));
+
+        $this->assertFalse($checker->valid(['not-an-array-group'], Tag::class));
+    }
+
+    public function testValidGroupEmptyTags(): void
+    {
+        $checker = new LimitTagGroupsChecker($this->getContainer()->get(ORMInterface::class));
+
+        $this->assertFalse($checker->valid([
+            ['operation' => LimitTagGroup::CONNECTION_AND, 'tags' => []],
+        ], Tag::class));
+    }
+
+    public function testValidGroupInvalidTagIdType(): void
+    {
+        $checker = new LimitTagGroupsChecker($this->getContainer()->get(ORMInterface::class));
+
+        $this->assertFalse($checker->valid([
+            ['operation' => LimitTagGroup::CONNECTION_AND, 'tags' => ['abc']],
+        ], Tag::class));
+    }
+}

--- a/tests/Feature/View/LimitTagGroupViewTest.php
+++ b/tests/Feature/View/LimitTagGroupViewTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\View;
+
+use App\Database\LimitTagGroup;
+use App\View\LimitTagGroupView;
+use Psr\Http\Message\ResponseInterface;
+use Tests\TestCase;
+
+class LimitTagGroupViewTest extends TestCase
+{
+    public function testJson(): void
+    {
+        $tagGroup = new LimitTagGroup();
+        $tagGroup->connection = LimitTagGroup::CONNECTION_OR;
+
+        $view = $this->getContainer()->get(LimitTagGroupView::class);
+
+        $this->assertInstanceOf(ResponseInterface::class, $view->json([$tagGroup]));
+    }
+}

--- a/tests/Feature/View/LimitViewTest.php
+++ b/tests/Feature/View/LimitViewTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Feature\View;
 
+use App\Database\LimitTagGroup;
 use App\View\LimitView;
+use Tests\Factories\LimitFactory;
 use Tests\TestCase;
 
 class LimitViewTest extends TestCase
@@ -14,5 +16,23 @@ class LimitViewTest extends TestCase
         $view = $this->getContainer()->get(LimitView::class);
 
         $this->assertNull($view->map(null));
+    }
+
+    public function testMapReturnsTagGroups(): void
+    {
+        $limit = LimitFactory::make();
+
+        $tagGroup = new LimitTagGroup();
+        $tagGroup->connection = LimitTagGroup::CONNECTION_AND;
+        $limit->tagGroups[] = $tagGroup;
+
+        $view = $this->getContainer()->get(LimitView::class);
+
+        $data = $view->map($limit);
+
+        $this->assertIsArray($data);
+        $this->assertSame([], $data['tags']);
+        $this->assertCount(1, $data['tagGroups']);
+        $this->assertSame('and', $data['tagGroups'][0]['connection']);
     }
 }


### PR DESCRIPTION
## Problem

Wallet limits could only be scoped to a single flat list of tags, combined implicitly with AND. There was no way to express "tag A OR tag B" or to combine multiple AND/OR groups in one limit (issue cash-track/frontend#152).

## Changes

- New `LimitTagGroup` entity: a limit now has one or more tag groups, each with its own `connection` (`and`/`or`) and its own set of tags, via a new `tag_limit_tag_groups` pivot.
- `LimitService::calculate()` sums each group's amount independently — a charge matching multiple groups is counted once per matching group, by design (no cross-group dedup).
- `ChargeRepository::totalByWalletPKAndTagPKs()` takes the group's connection: keeps the `HAVING COUNT(DISTINCT tag) = ?` for AND, drops it for OR.
- `LimitsController` builds/replaces `LimitTagGroup`s from the request's `tagGroups`, preserving per-user tag ownership checks (`TagRepository::findAllByPKsAndUserPKs`).
- New `LimitTagGroupsChecker` validates `tagGroups` shape (`{operation: 'and'|'or', tags: int[]}[]`) and tag existence.
- `CreateRequest`/`LimitView` switch from `tags` to `tagGroups`; legacy `tags` field is now hardcoded to `[]` in responses.
- Migration backfills existing limits into a single AND group carrying over their current flat tags, so calculation stays consistent for pre-existing data.
- `docs/openapi.yaml` updated with the new `LimitTagGroup`/`CreateLimitTagGroupRequest` schemas.

## Verification

- `composer phpunit`: 790/790 passing
- `composer phpcs`: clean
- `composer psalm`: no errors (strict)
- `npx @redocly/cli lint openapi.yaml`: clean (pre-existing unrelated warnings only)