### PR TITLE
feat(api): harden JWT access tokens with revocation, RS256 and JWKS

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -100,3 +100,7 @@ OTEL_PHP_TRACES_PROCESSOR=simple
 
 GIT_TAG=
 GIT_COMMIT=
+JWT_ISSUER=https://api.cash-track.app
+JWT_AUDIENCE=https://api.cash-track.app
+ACCESS_TOKEN_PUBLIC_KEY="{rsa-public-key}" # base64 encoded, optional — falls back to HS256 with JWT_SECRET when empty
+ACCESS_TOKEN_PRIVATE_KEY="{rsa-private-key}" # base64 encoded, optional — falls back to HS256 with JWT_SECRET when empty

--- a/app/config/jwt.php
+++ b/app/config/jwt.php
@@ -3,9 +3,13 @@
 declare(strict_types = 1);
 
 return [
-    'secret'     => env('JWT_SECRET'),
-    'ttl'        => env('JWT_TTL', 3600),
-    'refreshTtl' => env('JWT_REFRESH_TTL', 604800),
-    'publicKey'  => env('JWT_PUBLIC_KEY'),
-    'privateKey' => env('JWT_PRIVATE_KEY'),
+    'secret'           => env('JWT_SECRET'),
+    'ttl'              => env('JWT_TTL', 3600),
+    'refreshTtl'       => env('JWT_REFRESH_TTL', 604800),
+    'publicKey'        => env('JWT_PUBLIC_KEY'),
+    'privateKey'       => env('JWT_PRIVATE_KEY'),
+    'issuer'           => env('JWT_ISSUER', 'https://api.cash-track.app'),
+    'audience'         => env('JWT_AUDIENCE', 'https://api.cash-track.app'),
+    'accessPublicKey'  => env('ACCESS_TOKEN_PUBLIC_KEY'),
+    'accessPrivateKey' => env('ACCESS_TOKEN_PRIVATE_KEY'),
 ];

--- a/app/locale/en/messages.php
+++ b/app/locale/en/messages.php
@@ -5,6 +5,7 @@ return [
     'error_authentication_failure'          => 'Wrong email or password.',
     'error_token_authentication_failure'    => 'Invalid access token.',
     'error_authentication_exception'        => 'Unable to authenticate. Please try again later.',
+    'error_service_unavailable'             => 'Service is temporarily unavailable. Please try again shortly.',
     'error_unknown_currency'                => 'Unable to find currency.',
     'error_loading_default_currency'        => 'Unable to load default currency.',
     'error_password_confirmation_not_match' => 'The password confirmation does not match.',
@@ -18,6 +19,7 @@ return [
     'error_auth_passkey_invalid_challenge'  => 'Authentication attempt is not verified. Please try again.',
     'error_auth_passkey_invalid_response'   => 'Authentication response is not valid. Please try again.',
     'error_auth_passkey_unregistered'       => 'Provided passkey is not registered. Please use passkey added before.',
+    'error_auth_passkey_unavailable'        => 'Passkey sign-in is temporarily unavailable. Please try again shortly.',
 
     'email_confirmation_confirm_failure' => 'Unable to confirm your email.',
     'email_confirmation_ok'              => 'Your email has been confirmed.',

--- a/app/locale/uk/messages.php
+++ b/app/locale/uk/messages.php
@@ -5,6 +5,7 @@ return [
     'error_authentication_failure'          => 'Невірний email або пароль.',
     'error_token_authentication_failure'    => 'Хибний токен доступу.',
     'error_authentication_exception'        => 'Неможливо автентифікувати. Будь ласка, спробуйте ще раз пізніше.',
+    'error_service_unavailable'             => 'Сервіс тимчасово недоступний. Будь ласка, спробуйте пізніше.',
     'error_unknown_currency'                => 'Неможливо знайти валюту.',
     'error_loading_default_currency'        => 'Неможливо завантажити валюту за замовчуванням.',
     'error_password_confirmation_not_match' => 'Підтвердження паролю не збігається.',
@@ -18,6 +19,7 @@ return [
     'error_auth_passkey_invalid_challenge'  => 'Невідома спроба авторизації. Будь ласка, спробуйте ще раз.',
     'error_auth_passkey_invalid_response'   => 'Не успішна авторизація. Будь ласка, спробуйте ще раз.',
     'error_auth_passkey_unregistered'       => 'Ключ доступу не знайдено. Будь ласка, використовуйте ключ доступу доданий раніше.',
+    'error_auth_passkey_unavailable'        => 'Вхід за допомогою ключа доступу тимчасово недоступний. Будь ласка, спробуйте пізніше.',
 
     'email_confirmation_confirm_failure' => 'Неможливо підтвердити ваш email.',
     'email_confirmation_ok'              => 'Ваш email було підтверджено.',

--- a/app/src/Auth/Jwt/RefreshTokenStorage.php
+++ b/app/src/Auth/Jwt/RefreshTokenStorage.php
@@ -5,66 +5,57 @@ declare(strict_types=1);
 namespace App\Auth\Jwt;
 
 use App\Auth\RefreshTokenStorageInterface;
-use App\Config\JwtConfig;
+use Firebase\JWT\Key;
 use Spiral\Auth\Exception\TokenStorageException;
 use Spiral\Core\Attribute\Singleton;
 
 #[Singleton]
 final class RefreshTokenStorage extends TokenStorage implements RefreshTokenStorageInterface
 {
-    /**
-     * @var string
-     */
-    protected $alg = 'RS256';
-
-    /**
-     * @var string
-     */
-    protected $publicKey;
-
-    /**
-     * @var string
-     */
-    protected $privateKey;
-
-    /**
-     * RefreshTokenStorage constructor.
-     *
-     * @param \App\Config\JwtConfig $config
-     */
-    public function __construct(JwtConfig $config)
-    {
-        parent::__construct($config);
-
-        $this->ttl = $config->getRefreshTtl();
-        $this->publicKey = $config->getPublicKey();
-
-        if ($this->publicKey == '') {
-            throw new TokenStorageException('JWT public key are empty');
-        }
-
-        $this->privateKey = $config->getPrivateKey();
-
-        if ($this->privateKey == '') {
-            throw new TokenStorageException('JWT private key are empty');
-        }
-    }
-
-    /**
-     * @return string
-     */
     #[\Override]
-    protected function getVerifyKey(): string
+    protected function getSigningAlgorithm(): string
     {
-        return $this->publicKey;
+        return 'RS256';
     }
 
-    /**
-     * @return string
-     */
     #[\Override]
     protected function getSigningKey(): string
     {
-        return $this->privateKey;
+        return $this->config->getPrivateKey();
+    }
+
+    #[\Override]
+    protected function getVerificationKey(string $alg): ?Key
+    {
+        if ($alg !== 'RS256') {
+            return null;
+        }
+
+        return new Key($this->config->getPublicKey(), 'RS256');
+    }
+
+    #[\Override]
+    protected function getKeyId(): string
+    {
+        // Signed with a dedicated keypair, never published via the access token JWKS endpoint.
+        return '';
+    }
+
+    #[\Override]
+    protected function resolveTtl(): int
+    {
+        return $this->config->getRefreshTtl();
+    }
+
+    #[\Override]
+    protected function assertKeyMaterialConfigured(): void
+    {
+        if ($this->config->getPublicKey() === '') {
+            throw new TokenStorageException('JWT public key are empty');
+        }
+
+        if ($this->config->getPrivateKey() === '') {
+            throw new TokenStorageException('JWT private key are empty');
+        }
     }
 }

--- a/app/src/Auth/Jwt/TokenStorage.php
+++ b/app/src/Auth/Jwt/TokenStorage.php
@@ -7,6 +7,7 @@ namespace App\Auth\Jwt;
 use App\Config\JwtConfig;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
+use Redis;
 use Spiral\Auth\Exception\TokenStorageException;
 use Spiral\Auth\TokenInterface;
 use Spiral\Auth\TokenStorageInterface;
@@ -15,48 +16,45 @@ use Spiral\Core\Attribute\Singleton;
 #[Singleton]
 class TokenStorage implements TokenStorageInterface
 {
-    /**
-     * @var string
-     */
-    protected $secret;
+    private const string BLACKLIST_PREFIX = 'blacklist:jti:';
 
-    /**
-     * @var string
-     */
-    protected $alg = 'HS256';
+    protected readonly int $ttl;
 
-    /**
-     * @var int
-     */
-    protected $ttl;
+    public function __construct(
+        protected readonly JwtConfig $config,
+        protected readonly Redis $redis,
+    ) {
+        $this->assertKeyMaterialConfigured();
 
-    /**
-     * TokenStorage constructor.
-     *
-     * @param \App\Config\JwtConfig $config
-     */
-    public function __construct(JwtConfig $config)
-    {
-        $this->secret = $config->getSecret();
-
-        if ($this->secret == '') {
-            throw new TokenStorageException('JWT secret are empty');
-        }
-
-        $this->ttl = $config->getTtl();
+        $this->ttl = $this->resolveTtl();
     }
 
     #[\Override]
     public function load(string $id): ?TokenInterface
     {
-        // TODO. Validate token for the blacklisted
+        $alg = $this->peekAlgorithm($id);
+
+        if ($alg === null) {
+            return null;
+        }
+
+        $key = $this->getVerificationKey($alg);
+
+        if ($key === null) {
+            return null;
+        }
 
         try {
-            $payload = JWT::decode($id, new Key($this->getVerifyKey(), $this->alg));
-            return Token::fromPayload($id, (array) $payload);
+            $payload = (array) JWT::decode($id, $key);
         } catch (\Throwable $exception) {
             return null;
         }
+
+        if ($this->isBlacklisted((string) ($payload['jti'] ?? ''))) {
+            return null;
+        }
+
+        return Token::fromPayload($id, $payload);
     }
 
     #[\Override]
@@ -71,17 +69,17 @@ class TokenStorage implements TokenStorageInterface
             $expiresAt = (new \DateTimeImmutable())->setTimestamp($expire);
         }
 
-        // TODO. Prevent hardcoded data, resolve those values somehow
-
         $payload = array_merge($payload, [
-            'iss' => 'https://api.cash-track.app',
-            'aud' => 'https://api.cash-track.app',
+            'iss' => $this->config->getIssuer(),
+            'aud' => $this->config->getAudience(),
             'iat' => $now,
             'exp' => $expire,
-            'jti' => sha1((string) microtime(true)),
+            'jti' => bin2hex(random_bytes(16)),
         ]);
 
-        $jwt = JWT::encode($payload, $this->getSigningKey(), $this->alg);
+        $keyId = $this->getKeyId();
+
+        $jwt = JWT::encode($payload, $this->getSigningKey(), $this->getSigningAlgorithm(), $keyId !== '' ? $keyId : null);
 
         return new Token($jwt, $payload, $expiresAt);
     }
@@ -89,22 +87,115 @@ class TokenStorage implements TokenStorageInterface
     #[\Override]
     public function delete(TokenInterface $token): void
     {
-        // TODO: Implement delete() method. Add token to the blacklist
+        $jti = (string) ($token->getPayload()['jti'] ?? '');
+
+        if ($jti === '') {
+            return;
+        }
+
+        $expiresAt = $token->getExpiresAt();
+        $ttl = $expiresAt !== null ? $expiresAt->getTimestamp() - time() : $this->ttl;
+
+        if ($ttl <= 0) {
+            return;
+        }
+
+        try {
+            if (! $this->redis->isConnected()) {
+                return;
+            }
+
+            $this->redis->setex(self::BLACKLIST_PREFIX . $jti, $ttl, '1');
+        } catch (\Throwable $exception) {
+            // Best effort: a Redis outage must not break logout.
+        }
     }
 
-    /**
-     * @return string
-     */
-    protected function getVerifyKey(): string
+    /** Falls back to HS256 until the RSA access keypair is provisioned, so this deploys as-is. */
+    protected function getSigningAlgorithm(): string
     {
-        return $this->secret;
+        return $this->hasAccessRsaKeypair() ? 'RS256' : 'HS256';
     }
 
-    /**
-     * @return string
-     */
     protected function getSigningKey(): string
     {
-        return $this->secret;
+        return $this->hasAccessRsaKeypair() ? $this->config->getAccessPrivateKey() : $this->config->getSecret();
+    }
+
+    /**
+     * Fixed allow-list, so the token's own `alg` header can never steer verification to the
+     * wrong key. Blocks algorithm confusion: an RS256 token replayed as HS256 hits the HS256
+     * branch, which never touches the public key.
+     */
+    protected function getVerificationKey(string $alg): ?Key
+    {
+        return match ($alg) {
+            'RS256' => $this->hasAccessRsaKeypair() ? new Key($this->config->getAccessPublicKey(), 'RS256') : null,
+            'HS256' => $this->config->getSecret() !== '' ? new Key($this->config->getSecret(), 'HS256') : null,
+            default => null,
+        };
+    }
+
+    protected function getKeyId(): string
+    {
+        return $this->hasAccessRsaKeypair() ? $this->config->getAccessKeyId() : '';
+    }
+
+    protected function resolveTtl(): int
+    {
+        return $this->config->getTtl();
+    }
+
+    protected function assertKeyMaterialConfigured(): void
+    {
+        if ($this->config->getSecret() === '' && ! $this->hasAccessRsaKeypair()) {
+            throw new TokenStorageException('JWT secret and access token keypair are empty');
+        }
+    }
+
+    private function hasAccessRsaKeypair(): bool
+    {
+        return $this->config->getAccessPrivateKey() !== '' && $this->config->getAccessPublicKey() !== '';
+    }
+
+    private function peekAlgorithm(string $jwt): ?string
+    {
+        $segments = explode('.', $jwt);
+
+        if (count($segments) !== 3) {
+            return null;
+        }
+
+        try {
+            $header = JWT::jsonDecode(JWT::urlsafeB64Decode($segments[0]));
+        } catch (\Throwable $exception) {
+            return null;
+        }
+
+        if (! $header instanceof \stdClass || ! isset($header->alg) || ! is_string($header->alg)) {
+            return null;
+        }
+
+        return $header->alg;
+    }
+
+    /** Fails open: the signature is already verified, so a Redis outage must not block auth. */
+    private function isBlacklisted(string $jti): bool
+    {
+        if ($jti === '') {
+            return false;
+        }
+
+        try {
+            if (! $this->redis->isConnected()) {
+                return false;
+            }
+
+            $exists = $this->redis->exists(self::BLACKLIST_PREFIX . $jti);
+
+            return is_int($exists) && $exists > 0;
+        } catch (\Throwable $exception) {
+            return false;
+        }
     }
 }

--- a/app/src/Bootloader/RedisBootloader.php
+++ b/app/src/Bootloader/RedisBootloader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Bootloader;
 
 use App\Config\RedisConfig;
+use App\Redis\ReconnectingRedis;
 use Psr\Log\LoggerInterface;
 use Redis;
 use Spiral\Boot\Bootloader\Bootloader;
@@ -16,50 +17,9 @@ final class RedisBootloader extends Bootloader
     {
     }
 
+    /** Singleton for the worker's lifetime; ReconnectingRedis keeps it usable after a failure. */
     public function boot(Container $container): void
     {
-        $container->bindSingleton(Redis::class, fn (): Redis => $this->resolve());
-    }
-
-    protected function resolve(): Redis
-    {
-        $redis = new Redis();
-
-        if ($this->config->getHost() === '') {
-            return $redis;
-        }
-
-        $uri = "{$this->config->getHost()}:{$this->config->getPort()}";
-
-        $this->logger->info("Resolving a connection to a Redis instance [{$uri}]");
-
-        $status = $redis->pconnect(
-            $this->config->getHost(),
-            $this->config->getPort(),
-            $this->config->getTimeout(),
-            null,
-            $this->config->getRetryInterval(),
-            $this->config->getRetryTimeout(),
-        );
-
-        if (! $status) {
-            $this->logger->emergency("Connection to a Redis instance failed [{$uri}]: {$redis->getLastError()}");
-
-            throw new \RedisException("Unable to connect to Redis");
-        }
-
-        if ($redis->ping() === false) {
-            $this->logger->emergency("PING to a Redis instance is not successful [{$uri}]: {$redis->getLastError()}");
-
-            throw new \RedisException("Unable to connect to Redis");
-        }
-
-        $redis->setOption(Redis::OPT_PREFIX, $this->config->getPrefix());
-        $redis->setOption(Redis::OPT_MAX_RETRIES, $this->config->getMaxRetries());
-        $redis->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
-
-        $this->logger->info("Connection to a Redis instance has been established [{$uri}]");
-
-        return $redis;
+        $container->bindSingleton(Redis::class, fn (): Redis => new ReconnectingRedis($this->config, $this->logger));
     }
 }

--- a/app/src/Config/JwtConfig.php
+++ b/app/src/Config/JwtConfig.php
@@ -19,6 +19,10 @@ class JwtConfig extends InjectableConfig
         'refreshTtl' => null,
         'publicKey' => null,
         'privateKey' => null,
+        'issuer' => null,
+        'audience' => null,
+        'accessPublicKey' => null,
+        'accessPrivateKey' => null,
     ];
 
     public function getSecret(): string
@@ -44,5 +48,37 @@ class JwtConfig extends InjectableConfig
     public function getPrivateKey(): string
     {
         return base64_decode((string) $this->config['privateKey']);
+    }
+
+    public function getIssuer(): string
+    {
+        return (string) $this->config['issuer'];
+    }
+
+    public function getAudience(): string
+    {
+        return (string) $this->config['audience'];
+    }
+
+    public function getAccessPublicKey(): string
+    {
+        return base64_decode((string) $this->config['accessPublicKey']);
+    }
+
+    public function getAccessPrivateKey(): string
+    {
+        return base64_decode((string) $this->config['accessPrivateKey']);
+    }
+
+    /** JWT/JWKS `kid` for the current RSA access keypair; empty when none is configured. */
+    public function getAccessKeyId(): string
+    {
+        $publicKey = $this->getAccessPublicKey();
+
+        if ($publicKey === '') {
+            return '';
+        }
+
+        return substr(hash('sha256', $publicKey), 0, 16);
     }
 }

--- a/app/src/Controller/Auth/Controller.php
+++ b/app/src/Controller/Auth/Controller.php
@@ -53,4 +53,12 @@ abstract class Controller
             'message' => $message ?? $this->say('error_authentication_exception'),
         ], 500);
     }
+
+    protected function responseServiceUnavailable(string $error = '', ?string $message = null): ResponseInterface
+    {
+        return $this->response->json([
+            'error' => $error,
+            'message' => $message ?? $this->say('error_service_unavailable'),
+        ], 503);
+    }
 }

--- a/app/src/Controller/Auth/JwksController.php
+++ b/app/src/Controller/Auth/JwksController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Auth;
+
+use App\Service\Auth\JwksService;
+use Psr\Http\Message\ResponseInterface;
+use Spiral\Http\ResponseWrapper;
+use Spiral\Router\Annotation\Route;
+
+/**
+ * Publishes the access token RSA public key as a JWK Set (RFC 7517) so third parties can verify
+ * RS256-signed access tokens without contacting the API. Public, unauthenticated by design.
+ */
+final class JwksController
+{
+    public function __construct(
+        private readonly ResponseWrapper $response,
+        private readonly JwksService $jwksService,
+    ) {
+    }
+
+    #[Route(route: '/.well-known/jwks.json', name: 'auth.jwks', methods: 'GET')]
+    public function index(): ResponseInterface
+    {
+        return $this->response->json($this->jwksService->getKeySet());
+    }
+}

--- a/app/src/Controller/Auth/PasskeyController.php
+++ b/app/src/Controller/Auth/PasskeyController.php
@@ -9,6 +9,7 @@ use App\Service\Auth\AuthService;
 use App\Service\Auth\Passkey\Exception\InvalidChallengeException;
 use App\Service\Auth\Passkey\Exception\InvalidClientResponseException;
 use App\Service\Auth\Passkey\Exception\PasskeyNotFoundException;
+use App\Service\Auth\Passkey\Exception\PasskeyServiceUnavailableException;
 use App\Service\Auth\Passkey\Exception\UserNotFoundException;
 use App\Service\Auth\Passkey\PasskeyService;
 use App\View\UserView;
@@ -36,6 +37,11 @@ final class PasskeyController extends Controller
     {
         try {
             $response = $this->passkeyService->initAuth();
+        } catch (PasskeyServiceUnavailableException $exception) {
+            return $this->responseServiceUnavailable(
+                error: $exception->getMessage(),
+                message: $this->say('error_auth_passkey_unavailable'),
+            );
         } catch (\Throwable $exception) {
             return $this->responseAuthenticationException(
                 error: $exception->getMessage(),
@@ -70,6 +76,11 @@ final class PasskeyController extends Controller
             return $this->responseAuthenticationFailure(
                 error: $exception->getMessage(),
                 message: $this->say('error_authentication_passkey'),
+            );
+        } catch (PasskeyServiceUnavailableException $exception) {
+            return $this->responseServiceUnavailable(
+                error: $exception->getMessage(),
+                message: $this->say('error_auth_passkey_unavailable'),
             );
         } catch (\Throwable $exception) {
             return $this->responseAuthenticationException($exception->getMessage());

--- a/app/src/Controller/Profile/PasskeyController.php
+++ b/app/src/Controller/Profile/PasskeyController.php
@@ -9,6 +9,7 @@ use App\Database\Passkey;
 use App\Repository\PasskeyRepository;
 use App\Request\Profile\InitPasskeyRequest;
 use App\Request\Profile\StorePasskeyRequest;
+use App\Service\Auth\Passkey\Exception\PasskeyServiceUnavailableException;
 use App\Service\Auth\Passkey\PasskeyService;
 use App\View\PasskeysView;
 use App\View\PasskeyView;
@@ -44,6 +45,11 @@ final class PasskeyController extends AuthAwareController
     {
         try {
             $response = $this->passkeyAuthService->init($this->user, $request->name);
+        } catch (PasskeyServiceUnavailableException $exception) {
+            return $this->response->json([
+                'message' => $this->say('error_service_unavailable'),
+                'error'   => $exception->getMessage(),
+            ], 503);
         } catch (\Throwable $exception) {
             return $this->response->json([
                 'message' => $this->say('passkey_init_exception'),
@@ -59,6 +65,11 @@ final class PasskeyController extends AuthAwareController
     {
         try {
             $passkey = $this->passkeyAuthService->store($this->user, $request->challenge, $request->data);
+        } catch (PasskeyServiceUnavailableException $exception) {
+            return $this->response->json([
+                'message' => $this->say('error_service_unavailable'),
+                'error'   => $exception->getMessage(),
+            ], 503);
         } catch (\Throwable $exception) {
             return $this->response->json([
                 'message' => $this->say('passkey_store_exception'),

--- a/app/src/Redis/ReconnectingRedis.php
+++ b/app/src/Redis/ReconnectingRedis.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Redis;
+
+use App\Config\RedisConfig;
+use Psr\Log\LoggerInterface;
+use Redis;
+use RedisException;
+
+/**
+ * A \Redis client that never throws on connect and retries on a cooldown, so a worker recovers
+ * from a Redis outage without a restart. Consumers drive the retry via isConnected().
+ */
+final class ReconnectingRedis extends Redis
+{
+    /** Caps a sustained outage at one connect timeout per window instead of one per request. */
+    private const int RECONNECT_COOLDOWN_SECONDS = 5;
+
+    private ?float $lastAttemptAt = null;
+
+    public function __construct(
+        private readonly RedisConfig $config,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+
+        // Eager connect for consumers that skip their own isConnected() check. Never throws.
+        $this->isConnected();
+    }
+
+    #[\Override]
+    public function isConnected(): bool
+    {
+        if (parent::isConnected()) {
+            return true;
+        }
+
+        if (! $this->shouldAttemptConnect()) {
+            return false;
+        }
+
+        return $this->attemptConnect();
+    }
+
+    private function shouldAttemptConnect(): bool
+    {
+        if ($this->config->getHost() === '') {
+            return false;
+        }
+
+        if ($this->lastAttemptAt === null) {
+            return true;
+        }
+
+        return microtime(true) - $this->lastAttemptAt >= self::RECONNECT_COOLDOWN_SECONDS;
+    }
+
+    private function attemptConnect(): bool
+    {
+        $this->lastAttemptAt = microtime(true);
+
+        $uri = "{$this->config->getHost()}:{$this->config->getPort()}";
+
+        try {
+            $status = $this->pconnect(
+                $this->config->getHost(),
+                $this->config->getPort(),
+                $this->config->getTimeout(),
+                null,
+                $this->config->getRetryInterval(),
+                $this->config->getRetryTimeout(),
+            );
+
+            if (! $status || $this->ping() === false) {
+                throw new RedisException("Unable to connect to Redis: {$this->getLastError()}");
+            }
+        } catch (RedisException $exception) {
+            // Repeats every cooldown window: the only signal revocation and rate limiting are off.
+            $this->logger->emergency("Connection to a Redis instance failed [{$uri}]: {$exception->getMessage()}");
+
+            return false;
+        }
+
+        $this->setOption(Redis::OPT_PREFIX, $this->config->getPrefix());
+        $this->setOption(Redis::OPT_MAX_RETRIES, $this->config->getMaxRetries());
+        $this->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
+
+        $this->logger->info("Connection to a Redis instance has been established [{$uri}]");
+
+        return true;
+    }
+}

--- a/app/src/Service/Auth/JwksService.php
+++ b/app/src/Service/Auth/JwksService.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Auth;
+
+use App\Config\JwtConfig;
+use Firebase\JWT\JWT;
+
+final class JwksService
+{
+    public function __construct(
+        private readonly JwtConfig $config,
+    ) {
+    }
+
+    /**
+     * RFC 7517 JWK Set for the access token RSA public key. Returns an empty key set — never an
+     * error, and never the HMAC secret — when no RSA keypair is configured yet.
+     *
+     * @return array{keys: list<array{kty: string, use: string, alg: string, kid: string, n: string, e: string}>}
+     */
+    public function getKeySet(): array
+    {
+        $publicKey = $this->config->getAccessPublicKey();
+
+        if ($publicKey === '') {
+            return ['keys' => []];
+        }
+
+        $key = openssl_pkey_get_public($publicKey);
+
+        if ($key === false) {
+            return ['keys' => []];
+        }
+
+        $details = openssl_pkey_get_details($key);
+
+        if ($details === false || ! isset($details['rsa']['n'], $details['rsa']['e'])) {
+            return ['keys' => []];
+        }
+
+        return [
+            'keys' => [[
+                'kty' => 'RSA',
+                'use' => 'sig',
+                'alg' => 'RS256',
+                'kid' => $this->config->getAccessKeyId(),
+                'n' => JWT::urlsafeB64Encode($details['rsa']['n']),
+                'e' => JWT::urlsafeB64Encode($details['rsa']['e']),
+            ]],
+        ];
+    }
+}

--- a/app/src/Service/Auth/Passkey/Exception/PasskeyServiceUnavailableException.php
+++ b/app/src/Service/Auth/Passkey/Exception/PasskeyServiceUnavailableException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Auth\Passkey\Exception;
+
+/**
+ * Thrown when passkey challenge storage (Redis) is unreachable. Passkey ceremonies have no
+ * degraded mode, so this is a distinct, retryable failure rather than a generic exception.
+ */
+final class PasskeyServiceUnavailableException extends \RuntimeException
+{
+}

--- a/app/src/Service/Auth/Passkey/PasskeyService.php
+++ b/app/src/Service/Auth/Passkey/PasskeyService.php
@@ -12,12 +12,14 @@ use App\Repository\UserRepository;
 use App\Service\Auth\Passkey\Exception\InvalidChallengeException;
 use App\Service\Auth\Passkey\Exception\InvalidClientResponseException;
 use App\Service\Auth\Passkey\Exception\PasskeyNotFoundException;
+use App\Service\Auth\Passkey\Exception\PasskeyServiceUnavailableException;
 use App\Service\Auth\Passkey\Exception\UserNotFoundException;
 use App\Service\Auth\Passkey\Response\DataEncoder;
 use App\Service\Auth\Passkey\Response\PasskeyInitResponse;
 use Cose\Algorithm\Manager;
 use Cycle\ORM\EntityManagerInterface;
 use ParagonIE\ConstantTime\Base64UrlSafe;
+use Psr\Log\LoggerInterface;
 use Redis;
 use Symfony\Component\Serializer\SerializerInterface;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
@@ -52,6 +54,7 @@ class PasskeyService
         private readonly EntityManagerInterface $tr,
         private readonly PasskeyRepository $repository,
         private readonly UserRepository $userRepository,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -103,6 +106,9 @@ class PasskeyService
         );
     }
 
+    /**
+     * @throws PasskeyServiceUnavailableException
+     */
     public function initAuth(): \JsonSerializable
     {
         $challenge = $this->generateChallenge();
@@ -130,6 +136,7 @@ class PasskeyService
      * @throws \App\Service\Auth\Passkey\Exception\InvalidClientResponseException
      * @throws \App\Service\Auth\Passkey\Exception\PasskeyNotFoundException
      * @throws \App\Service\Auth\Passkey\Exception\UserNotFoundException
+     * @throws PasskeyServiceUnavailableException
      */
     public function authenticate(string $challenge, string $data): User
     {
@@ -179,6 +186,9 @@ class PasskeyService
         return $user;
     }
 
+    /**
+     * @throws PasskeyServiceUnavailableException
+     */
     public function store(User $user, string $challenge, string $data): Passkey
     {
         $authenticatorAttestationResponseValidator = AuthenticatorAttestationResponseValidator::create(
@@ -231,6 +241,9 @@ class PasskeyService
         return $passkey;
     }
 
+    /**
+     * @throws PasskeyServiceUnavailableException
+     */
     public function init(User $user, string $keyName): \JsonSerializable
     {
         $challenge = $this->generateChallenge();
@@ -271,9 +284,17 @@ class PasskeyService
         $creation = new CreationChallenge($this->getSerializer(), $name, $challenge, $options);
 
         $cacheKey = $this->challengeCacheKey($challenge);
+        // Outside the try block: a serialization failure is a bug, not a Redis outage.
+        $data = $creation->toArray();
 
-        $this->redis->hMSet($cacheKey, $creation->toArray());
-        $this->redis->expire($cacheKey, self::CHALLENGE_TTL_SEC);
+        $this->assertRedisAvailable();
+
+        try {
+            $this->redis->hMSet($cacheKey, $data);
+            $this->redis->expire($cacheKey, self::CHALLENGE_TTL_SEC);
+        } catch (\Throwable $exception) {
+            throw $this->unavailable($exception);
+        }
     }
 
     protected function storeRequestOptions(string $challenge, PublicKeyCredentialRequestOptions $options): void
@@ -281,20 +302,42 @@ class PasskeyService
         $request = new RequestChallenge($this->getSerializer(), $challenge, $options);
 
         $cacheKey = $this->challengeCacheKey($challenge);
+        // Outside the try block: see storeCreationOptions().
+        $data = $request->toArray();
 
-        $this->redis->hMSet($cacheKey, $request->toArray());
-        $this->redis->expire($cacheKey, self::CHALLENGE_TTL_SEC);
+        $this->assertRedisAvailable();
+
+        try {
+            $this->redis->hMSet($cacheKey, $data);
+            $this->redis->expire($cacheKey, self::CHALLENGE_TTL_SEC);
+        } catch (\Throwable $exception) {
+            throw $this->unavailable($exception);
+        }
     }
 
     protected function forgetOptions(string $challenge): void
     {
         $cacheKey = $this->challengeCacheKey($challenge);
-        $this->redis->del($cacheKey);
+
+        $this->assertRedisAvailable();
+
+        try {
+            $this->redis->del($cacheKey);
+        } catch (\Throwable $exception) {
+            throw $this->unavailable($exception);
+        }
     }
 
     protected function getCreationOptions(string $challenge): ?CreationChallenge
     {
-        $data = $this->redis->hGetAll($this->challengeCacheKey($challenge));
+        $this->assertRedisAvailable();
+
+        try {
+            $data = $this->redis->hGetAll($this->challengeCacheKey($challenge));
+        } catch (\Throwable $exception) {
+            throw $this->unavailable($exception);
+        }
+
         if (! is_array($data)) {
             return null;
         }
@@ -304,7 +347,14 @@ class PasskeyService
 
     protected function getRequestOptions(string $challenge): ?RequestChallenge
     {
-        $data = $this->redis->hGetAll($this->challengeCacheKey($challenge));
+        $this->assertRedisAvailable();
+
+        try {
+            $data = $this->redis->hGetAll($this->challengeCacheKey($challenge));
+        } catch (\Throwable $exception) {
+            throw $this->unavailable($exception);
+        }
+
         if (! is_array($data)) {
             return null;
         }
@@ -315,6 +365,32 @@ class PasskeyService
     protected function challengeCacheKey(string $challenge): string
     {
         return "passkeys:challenge:{$challenge}";
+    }
+
+    /**
+     * Triggers ReconnectingRedis's reconnect and turns a still-down Redis into a 503, not a 500.
+     *
+     * @throws PasskeyServiceUnavailableException
+     */
+    private function assertRedisAvailable(): void
+    {
+        if (! $this->redis->isConnected()) {
+            throw new PasskeyServiceUnavailableException('Passkey challenge storage is currently unavailable.');
+        }
+    }
+
+    /** Covers a connected client failing mid-command; logs the original exception, which the response drops. */
+    private function unavailable(\Throwable $exception): PasskeyServiceUnavailableException
+    {
+        $this->logger->error('Passkey challenge storage is unavailable', [
+            'error' => get_class($exception),
+            'message' => $exception->getMessage(),
+        ]);
+
+        return new PasskeyServiceUnavailableException(
+            'Passkey challenge storage is currently unavailable.',
+            previous: $exception,
+        );
     }
 
     protected function getUserEntity(User $user): PublicKeyCredentialUserEntity

--- a/app/src/Service/RateLimit/RedisRateLimit.php
+++ b/app/src/Service/RateLimit/RedisRateLimit.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\RateLimit;
 
+use Psr\Log\LoggerInterface;
 use Redis;
 
 final class RedisRateLimit implements RateLimitInterface
@@ -12,6 +13,7 @@ final class RedisRateLimit implements RateLimitInterface
 
     public function __construct(
         protected readonly Redis $redis,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -24,14 +26,26 @@ final class RedisRateLimit implements RateLimitInterface
 
         $key = static::PREFIX . $rule->key();
 
-        $counter = $this->redis->incr($key);
+        // isConnected() can be stale, so each command is guarded to fail open on a mid-outage
+        // drop. A false return (not a throw) means a reachable server replied badly — still throws.
+        try {
+            $counter = $this->redis->incr($key);
+        } catch (\Throwable $exception) {
+            return $this->unavailable($rule, $exception);
+        }
+
         if (! is_int($counter)) {
             throw new \RuntimeException(
                 "Unable to increment rate limit counter: {$this->redis->getLastError()}"
             );
         }
 
-        $ttl = $this->redis->ttl($key);
+        try {
+            $ttl = $this->redis->ttl($key);
+        } catch (\Throwable $exception) {
+            return $this->unavailable($rule, $exception);
+        }
+
         if (! is_int($ttl)) {
             throw new \RuntimeException(
                 "Unable to retrieve rate limit counter time to live: {$this->redis->getLastError()}"
@@ -39,7 +53,13 @@ final class RedisRateLimit implements RateLimitInterface
         }
 
         if ($ttl === -1) {
-            if ($this->redis->expire($key, $rule->ttl()) === false) {
+            try {
+                $expired = $this->redis->expire($key, $rule->ttl());
+            } catch (\Throwable $exception) {
+                return $this->unavailable($rule, $exception);
+            }
+
+            if ($expired === false) {
                 throw new \RuntimeException(
                     "Unable to set expiration for rate limit counter: {$this->redis->getLastError()}"
                 );
@@ -55,5 +75,16 @@ final class RedisRateLimit implements RateLimitInterface
         }
 
         return $hit;
+    }
+
+    /** Fails open: brute-force protection is off for the outage, so the gap must be logged. */
+    private function unavailable(RuleInterface $rule, \Throwable $exception): RateLimitHitInterface
+    {
+        $this->logger->error('Rate limiting is unavailable; failing open', [
+            'error' => get_class($exception),
+            'message' => $exception->getMessage(),
+        ]);
+
+        return new RateLimitHit($rule);
     }
 }

--- a/docs/deployment/2026-08-07-jwt-access-token-hardening.md
+++ b/docs/deployment/2026-08-07-jwt-access-token-hardening.md
@@ -1,0 +1,148 @@
+# JWT access token hardening
+
+Adds RS256 support for access tokens (HS256 remains the default), server-side token
+revocation on logout via a Redis blacklist, and graceful degradation when Redis is down.
+
+## TL;DR
+
+This branch is safe to deploy as-is. No secrets need to change for the deploy itself:
+
+- `ACCESS_TOKEN_PUBLIC_KEY` / `ACCESS_TOKEN_PRIVATE_KEY` are unset in every environment today,
+  so `TokenStorage` falls back to HS256 with the existing `JWT_SECRET` — identical to current
+  behavior, just now with revocation support added on top.
+- Nothing new is required to be present. Nothing hard-fails if it's missing.
+- This is **not** a coordinated cutover. Deploy the code first, enable RS256 later (next
+  section), on your own schedule.
+
+The one thing this deploy does change immediately: **logout now actually revokes tokens**
+(previously a no-op — `TokenStorage::delete()` was a `// TODO` stub). And a Redis outage now
+degrades auth/rate-limiting instead of crashing them (see "Redis outage behavior" below).
+
+Deploying the code alone is not enough — RoadRunner keeps old workers running until told
+otherwise:
+
+```
+./rr reset
+```
+
+`.rr.yaml` has no file watcher configured, so skip this and you'll keep serving the previous
+build. (The tester hit this.)
+
+## Enabling RS256 for access tokens
+
+Whenever you're ready — this is independent of the code deploy above.
+
+```bash
+openssl genrsa -out access-token-private.pem 2048
+openssl rsa -in access-token-private.pem -pubout -out access-token-public.pem
+
+base64 -i access-token-private.pem | tr -d '\n' # -> ACCESS_TOKEN_PRIVATE_KEY
+base64 -i access-token-public.pem  | tr -d '\n' # -> ACCESS_TOKEN_PUBLIC_KEY
+```
+
+Set both as env vars (same base64-encoded-PEM convention as the existing
+`JWT_PUBLIC_KEY`/`JWT_PRIVATE_KEY`):
+
+- `ACCESS_TOKEN_PUBLIC_KEY`
+- `ACCESS_TOKEN_PRIVATE_KEY`
+
+**Generate a keypair dedicated to access tokens — do not reuse `JWT_PUBLIC_KEY`/
+`JWT_PRIVATE_KEY`.** That pair signs refresh tokens and is unrelated to this change. Sharing a
+keypair between the two means a leaked access-token key also lets an attacker mint refresh
+tokens, and vice versa; keeping them separate bounds the blast radius of either leaking.
+
+Once both vars are set and the app restarts, new access tokens sign with RS256 automatically —
+no other config change needed.
+
+### JWT_SECRET removal — timing trap
+
+Do not remove `JWT_SECRET` immediately after setting the RS256 keys. Access tokens issued
+*before* the RS256 keys were set are still HS256 and still valid until they expire — pulling
+`JWT_SECRET` breaks every one of those sessions immediately (`load()` returns null for HS256
+tokens once the secret is gone, i.e. an immediate 401 on the user's next request).
+
+**Wait at least `JWT_TTL` seconds after the RS256 deploy before removing `JWT_SECRET`.**
+Default `JWT_TTL` is 3600 (1 hour). If you've overridden `JWT_TTL`, use that value instead.
+
+## JWT_ISSUER / JWT_AUDIENCE
+
+Optional. Default to `https://api.cash-track.app` in both cases — correct for production,
+no action needed there.
+
+For staging, set both to the staging API URL so `iss`/`aud` in issued tokens reflect where they
+were actually issued.
+
+## New Redis dependency: logout blacklist
+
+Logout now writes a blacklist entry for the revoked token(s) (access, and refresh if one was
+supplied).
+
+- Keyspace: `CT:blacklist:jti:*` (`CT:` is the standing connection-level prefix from
+  `app/config/redis.php`; `blacklist:jti:` + the token's `jti` is the key).
+- TTL: set to whatever time remains on the token, capped at `JWT_TTL` for access-token entries
+  and `JWT_REFRESH_TTL` (default 604800s, 7 days) for refresh-token entries.
+- Self-expiring and bounded — every key TTLs out on its own; nothing to prune or monitor for
+  unbounded growth.
+
+## Redis outage behavior
+
+This differs from before this branch — previously a Redis outage on the auth path either wasn't
+possible (revocation didn't exist) or crashed the request. Now:
+
+- **Auth (token verification + logout revocation)**: fails open. Revocation is not enforced
+  during the outage (a blacklisted token could still verify), and logout silently skips the
+  blacklist write. Nothing is logged from this path specifically — see below for what to watch
+  instead.
+- **Rate limiting**: fails open (requests are not throttled) during the outage. This path *does*
+  log at `error` level, but only for the "was connected, dropped mid-command" case, not a
+  sustained outage — see below.
+- **Passkey endpoints**: return `503` — passkey ceremonies have no degraded mode.
+- **Self-heals automatically**: the shared Redis client retries on a 5-second cooldown
+  (`ReconnectingRedis::RECONNECT_COOLDOWN_SECONDS`) and starts working again within ~5s of Redis
+  coming back, with no worker restart needed.
+
+What to grep for:
+
+```
+# The actual heartbeat of the outage — fires roughly every 5s for its entire duration:
+grep "Connection to a Redis instance failed" runtime/logs/app.log
+
+# Recovery:
+grep "Connection to a Redis instance has been established" runtime/logs/app.log
+```
+
+Note the `error`-level lines mentioned above ("Rate limiting is unavailable; failing open",
+"Passkey challenge storage is unavailable") only fire on a connected-client-then-drops-mid-command
+blip, not the common case of a fully-down Redis — don't rely on them as the primary outage
+signal, use the `emergency`-level connection-failed line above instead.
+
+## Verifying RS256 took effect
+
+1. Log in, grab the fresh access token, decode its header:
+   ```bash
+   echo '<token>' | cut -d. -f1 | base64 -d
+   ```
+   Confirm `"alg":"RS256"` (was `"HS256"`).
+2. Check the JWKS endpoint returns a populated key set:
+   ```bash
+   curl https://<api-host>/.well-known/jwks.json
+   ```
+   Expect one entry with `kty: RSA`, `use: sig`, `alg: RS256`, a non-empty `kid`, and populated
+   `n`/`e`. An empty `{"keys": []}` means the app hasn't picked up the RSA keypair — check
+   `ACCESS_TOKEN_PUBLIC_KEY`/`ACCESS_TOKEN_PRIVATE_KEY` are actually set and `./rr reset` ran.
+
+## Rollback
+
+If you revert this code after RS256 tokens have already been issued (RS256 keys were set and
+the app has been running with them for a while):
+
+- **Access tokens issued under RS256 stop verifying.** The rolled-back code has no RS256 path
+  at all, so `load()` returns null for them — those users get a 401 on their next request and
+  have to log in again. There's no way around this short of not rolling back.
+- **Refresh tokens are unaffected.** They were already RS256 before this branch
+  (`JWT_PUBLIC_KEY`/`JWT_PRIVATE_KEY`), and that keypair/algorithm didn't change — refresh flow
+  keeps working across the rollback.
+- **Logout reverts to a no-op**, same as before this branch — not a new regression, just losing
+  the revocation this branch added.
+
+Rolling back before ever setting the RS256 keys is a pure no-op — nothing to clean up.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -233,11 +233,12 @@ paths:
   /auth/logout:
     post:
       operationId: authLogout
-      summary: Logout / invalidate refresh token
+      summary: Logout / invalidate refresh token and access token
       description: |
-        Revokes the refresh token so it cannot be used to mint new access tokens.
-        Pass the refresh token in the body to invalidate a specific session; omit
-        it to invalidate the session derived from the current access token.
+        Revokes the current access token and the refresh token so neither can be used again —
+        the access token is blacklisted server-side and rejected on any subsequent request even
+        before it naturally expires. Pass the refresh token in the body to invalidate a specific
+        session; omit it to invalidate the session derived from the current access token.
       tags: [Auth]
       security:
         - bearerAuth: []
@@ -256,6 +257,51 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "200":
           description: Logged out successfully
+
+  /.well-known/jwks.json:
+    get:
+      operationId: authJwks
+      summary: Access token JSON Web Key Set
+      description: |
+        Publishes the access token's RSA public key as a JWK Set (RFC 7517) so third parties can
+        verify RS256-signed access tokens without calling the API. No authentication required.
+
+        Returns an empty key set (`{"keys": []}`) — never an error — when the API is still
+        signing access tokens with HS256 (no RSA keypair configured yet). The HMAC secret used
+        for HS256 is never exposed through this endpoint.
+      tags: [Auth]
+      security: []
+      responses:
+        "200":
+          description: JWK Set for the current access token signing key
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  keys:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        kty:
+                          type: string
+                          example: RSA
+                        use:
+                          type: string
+                          example: sig
+                        alg:
+                          type: string
+                          example: RS256
+                        kid:
+                          type: string
+                          description: Stable identifier for this keypair.
+                        n:
+                          type: string
+                          description: RSA modulus, base64url-encoded without padding.
+                        e:
+                          type: string
+                          description: RSA public exponent, base64url-encoded without padding.
 
   /auth/login/passkey/init:
     get:
@@ -277,6 +323,8 @@ paths:
               schema:
                 type: object
                 description: Raw `PublicKeyCredentialRequestOptions` JSON
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /auth/login/passkey:
     post:
@@ -304,6 +352,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "422":
           $ref: "#/components/responses/ValidationError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /auth/provider/google:
     post:
@@ -793,6 +843,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "422":
           $ref: "#/components/responses/ValidationError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /profile/passkey/init:
     post:
@@ -827,6 +879,8 @@ paths:
               schema:
                 type: object
                 description: Raw `PublicKeyCredentialCreationOptions` JSON
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /profile/passkey/{id}:
     delete:
@@ -3223,6 +3277,27 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ValidationError"
+
+    ServiceUnavailable:
+      description: |
+        Passkey challenge storage (Redis) is temporarily unreachable. Passkey ceremonies have
+        no degraded mode, so this is surfaced as a distinct, retryable failure rather than a
+        generic 500. No `Retry-After` header is sent: the outage duration is not predictable
+        from the server side, and this flow is a live, user-driven ceremony rather than an
+        automated retrier — advertising a fixed delay would be a false precision claim during
+        exactly the sustained-outage case this response exists for.
+      headers:
+        X-Ct-Api-Version:
+          $ref: "#/components/headers/ApiVersion"
+        X-Ct-Api-Sha:
+          $ref: "#/components/headers/ApiSha"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: Passkey challenge storage is currently unavailable.
+            message: Passkey sign-in is temporarily unavailable. Please try again shortly.
 
 # ---------------------------------------------------------------------------
 # GLOBAL SECURITY

--- a/tests/Feature/Auth/Jwt/RefreshTokenStorageTest.php
+++ b/tests/Feature/Auth/Jwt/RefreshTokenStorageTest.php
@@ -6,33 +6,119 @@ namespace Tests\Feature\Auth\Jwt;
 
 use App\Auth\Jwt\RefreshTokenStorage;
 use App\Config\JwtConfig;
+use Firebase\JWT\JWT;
+use PHPUnit\Framework\MockObject\MockObject;
+use Redis;
 use Spiral\Auth\Exception\TokenStorageException;
 use Tests\TestCase;
+use Tests\Traits\ProvideRsaKeyPair;
 
 class RefreshTokenStorageTest extends TestCase
 {
+    use ProvideRsaKeyPair;
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function makeConfig(array $overrides = []): JwtConfig&MockObject
+    {
+        $values = array_merge([
+            'getRefreshTtl' => 3600,
+            'getPublicKey' => '123',
+            'getPrivateKey' => '123',
+            'getIssuer' => 'https://api.cash-track.app',
+            'getAudience' => 'https://api.cash-track.app',
+        ], $overrides);
+
+        $config = $this->getMockBuilder(JwtConfig::class)->getMock();
+
+        foreach ($values as $method => $value) {
+            $config->method($method)->willReturn($value);
+        }
+
+        return $config;
+    }
+
+    private function disconnectedRedis(): Redis&MockObject
+    {
+        $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected'])->getMock();
+        $redis->method('isConnected')->willReturn(false);
+
+        return $redis;
+    }
+
     public function testEmptyPublicKeyThrownException(): void
     {
-        $config = $this->getMockBuilder(JwtConfig::class)->getMock();
-        $config->method('getSecret')->willReturn('123');
-        $config->method('getRefreshTtl')->willReturn(1);
-        $config->method('getPublicKey')->willReturn('');
+        $config = $this->makeConfig(['getPublicKey' => '']);
 
         $this->expectException(TokenStorageException::class);
 
-        new RefreshTokenStorage($config);
+        new RefreshTokenStorage($config, $this->disconnectedRedis());
     }
 
     public function testEmptyPrivateKeyThrownException(): void
     {
-        $config = $this->getMockBuilder(JwtConfig::class)->getMock();
-        $config->method('getSecret')->willReturn('123');
-        $config->method('getRefreshTtl')->willReturn(1);
-        $config->method('getPublicKey')->willReturn('123');
-        $config->method('getPrivateKey')->willReturn('');
+        $config = $this->makeConfig(['getPrivateKey' => '']);
 
         $this->expectException(TokenStorageException::class);
 
-        new RefreshTokenStorage($config);
+        new RefreshTokenStorage($config, $this->disconnectedRedis());
+    }
+
+    public function testRoundTripUsesRs256WithDedicatedKeypair(): void
+    {
+        $keyPair = $this->generateRsaKeyPair();
+        $config = $this->makeConfig([
+            'getPublicKey' => $keyPair['publicKey'],
+            'getPrivateKey' => $keyPair['privateKey'],
+        ]);
+
+        $storage = new RefreshTokenStorage($config, $this->disconnectedRedis());
+
+        $token = $storage->create(['sub' => 7, 'kind' => 'refresh']);
+        $loaded = $storage->load($token->getID());
+
+        $this->assertNotNull($loaded);
+        $this->assertEquals(7, $loaded->getPayload()['sub']);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $token->getPayload()['jti']);
+    }
+
+    public function testHs256TokenIsRejectedEvenIfSignedWithPublicKeyAsSecret(): void
+    {
+        $keyPair = $this->generateRsaKeyPair();
+        $config = $this->makeConfig([
+            'getPublicKey' => $keyPair['publicKey'],
+            'getPrivateKey' => $keyPair['privateKey'],
+        ]);
+
+        $storage = new RefreshTokenStorage($config, $this->disconnectedRedis());
+
+        $forgedToken = JWT::encode([
+            'sub' => 1,
+            'jti' => bin2hex(random_bytes(16)),
+        ], $keyPair['publicKey'], 'HS256');
+
+        $this->assertNull($storage->load($forgedToken));
+    }
+
+    public function testDeleteBlacklistsTokenWithRemainingTtl(): void
+    {
+        $keyPair = $this->generateRsaKeyPair();
+        $config = $this->makeConfig([
+            'getPublicKey' => $keyPair['publicKey'],
+            'getPrivateKey' => $keyPair['privateKey'],
+        ]);
+
+        $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected', 'setex'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->expects($this->once())->method('setex')->with(
+            $this->stringStartsWith('blacklist:jti:'),
+            $this->greaterThan(0),
+            '1',
+        );
+
+        $storage = new RefreshTokenStorage($config, $redis);
+
+        $storage->delete($storage->create(['sub' => 1, 'kind' => 'refresh']));
     }
 }

--- a/tests/Feature/Auth/Jwt/TokenStorageTest.php
+++ b/tests/Feature/Auth/Jwt/TokenStorageTest.php
@@ -6,18 +6,284 @@ namespace Tests\Feature\Auth\Jwt;
 
 use App\Auth\Jwt\TokenStorage;
 use App\Config\JwtConfig;
+use Firebase\JWT\JWT;
+use PHPUnit\Framework\MockObject\MockObject;
+use Redis;
 use Spiral\Auth\Exception\TokenStorageException;
 use Tests\TestCase;
+use Tests\Traits\ProvideRsaKeyPair;
 
 class TokenStorageTest extends TestCase
 {
-    public function testEmptySecretThrownException(): void
+    use ProvideRsaKeyPair;
+
+    private const HMAC_SECRET = 'test-hmac-secret-at-least-32-bytes-long';
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function makeConfig(array $overrides = []): JwtConfig&MockObject
     {
+        $values = array_merge([
+            'getSecret' => self::HMAC_SECRET,
+            'getTtl' => 3600,
+            'getIssuer' => 'https://api.cash-track.app',
+            'getAudience' => 'https://api.cash-track.app',
+            'getAccessPublicKey' => '',
+            'getAccessPrivateKey' => '',
+            'getAccessKeyId' => '',
+        ], $overrides);
+
         $config = $this->getMockBuilder(JwtConfig::class)->getMock();
-        $config->method('getSecret')->willReturn('');
+
+        foreach ($values as $method => $value) {
+            $config->method($method)->willReturn($value);
+        }
+
+        return $config;
+    }
+
+    private function disconnectedRedis(): Redis&MockObject
+    {
+        $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected'])->getMock();
+        $redis->method('isConnected')->willReturn(false);
+
+        return $redis;
+    }
+
+    public function testEmptySecretAndAccessKeypairThrownException(): void
+    {
+        $config = $this->makeConfig(['getSecret' => '']);
 
         $this->expectException(TokenStorageException::class);
 
-        new TokenStorage($config);
+        new TokenStorage($config, $this->disconnectedRedis());
+    }
+
+    public function testConstructsWithSecretOnly(): void
+    {
+        $storage = new TokenStorage($this->makeConfig(), $this->disconnectedRedis());
+
+        $this->assertInstanceOf(TokenStorage::class, $storage);
+    }
+
+    public function testConstructsWithAccessKeypairEvenWithoutSecret(): void
+    {
+        $keyPair = $this->generateRsaKeyPair();
+
+        $config = $this->makeConfig([
+            'getSecret' => '',
+            'getAccessPublicKey' => $keyPair['publicKey'],
+            'getAccessPrivateKey' => $keyPair['privateKey'],
+            'getAccessKeyId' => 'abc123',
+        ]);
+
+        $storage = new TokenStorage($config, $this->disconnectedRedis());
+
+        $this->assertInstanceOf(TokenStorage::class, $storage);
+    }
+
+    public function testCreateGeneratesRandomJti(): void
+    {
+        $storage = new TokenStorage($this->makeConfig(), $this->disconnectedRedis());
+
+        $tokenOne = $storage->create(['sub' => 1]);
+        $tokenTwo = $storage->create(['sub' => 1]);
+
+        $this->assertNotEquals($tokenOne->getPayload()['jti'], $tokenTwo->getPayload()['jti']);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $tokenOne->getPayload()['jti']);
+    }
+
+    public function testCreateUsesConfiguredIssuerAndAudience(): void
+    {
+        $config = $this->makeConfig([
+            'getIssuer' => 'https://issuer.test',
+            'getAudience' => 'https://audience.test',
+        ]);
+        $storage = new TokenStorage($config, $this->disconnectedRedis());
+
+        $token = $storage->create(['sub' => 1]);
+
+        $this->assertEquals('https://issuer.test', $token->getPayload()['iss']);
+        $this->assertEquals('https://audience.test', $token->getPayload()['aud']);
+    }
+
+    public function testHs256RoundTrip(): void
+    {
+        $storage = new TokenStorage($this->makeConfig(), $this->disconnectedRedis());
+
+        $token = $storage->create(['sub' => 42]);
+        $loaded = $storage->load($token->getID());
+
+        $this->assertNotNull($loaded);
+        $this->assertEquals(42, $loaded->getPayload()['sub']);
+    }
+
+    public function testRs256RoundTripAndKeyIdHeader(): void
+    {
+        $keyPair = $this->generateRsaKeyPair();
+        $config = $this->makeConfig([
+            'getAccessPublicKey' => $keyPair['publicKey'],
+            'getAccessPrivateKey' => $keyPair['privateKey'],
+            'getAccessKeyId' => 'test-kid',
+        ]);
+        $storage = new TokenStorage($config, $this->disconnectedRedis());
+
+        $token = $storage->create(['sub' => 42]);
+        $loaded = $storage->load($token->getID());
+
+        $this->assertNotNull($loaded);
+        $this->assertEquals(42, $loaded->getPayload()['sub']);
+
+        [$headerB64] = explode('.', $token->getID());
+        $header = json_decode(JWT::urlsafeB64Decode($headerB64), true);
+
+        $this->assertEquals('RS256', $header['alg']);
+        $this->assertEquals('test-kid', $header['kid']);
+    }
+
+    public function testHs256TokenStillVerifiesDuringMigrationWindow(): void
+    {
+        // Signing always prefers RS256 once configured, so build the legacy HS256 shape
+        // directly to simulate a pre-migration token.
+        $keyPair = $this->generateRsaKeyPair();
+        $config = $this->makeConfig([
+            'getAccessPublicKey' => $keyPair['publicKey'],
+            'getAccessPrivateKey' => $keyPair['privateKey'],
+            'getAccessKeyId' => 'test-kid',
+        ]);
+        $storage = new TokenStorage($config, $this->disconnectedRedis());
+
+        $legacyToken = JWT::encode([
+            'sub' => 42,
+            'iat' => time(),
+            'exp' => time() + 3600,
+            'jti' => bin2hex(random_bytes(16)),
+        ], self::HMAC_SECRET, 'HS256');
+
+        $loaded = $storage->load($legacyToken);
+
+        $this->assertNotNull($loaded);
+        $this->assertEquals(42, $loaded->getPayload()['sub']);
+    }
+
+    public function testAlgorithmConfusionAttackIsRejected(): void
+    {
+        // Replays the RS256 public key as an HMAC secret with `alg` flipped to HS256; must
+        // fail to verify.
+        $keyPair = $this->generateRsaKeyPair();
+        $config = $this->makeConfig([
+            'getAccessPublicKey' => $keyPair['publicKey'],
+            'getAccessPrivateKey' => $keyPair['privateKey'],
+            'getAccessKeyId' => 'test-kid',
+        ]);
+        $storage = new TokenStorage($config, $this->disconnectedRedis());
+
+        $forgedToken = JWT::encode([
+            'sub' => 1,
+            'jti' => bin2hex(random_bytes(16)),
+        ], $keyPair['publicKey'], 'HS256');
+
+        $this->assertNull($storage->load($forgedToken));
+    }
+
+    public function testMalformedTokenIsRejected(): void
+    {
+        $storage = new TokenStorage($this->makeConfig(), $this->disconnectedRedis());
+
+        $this->assertNull($storage->load('not-a-jwt'));
+    }
+
+    public function testBlacklistedTokenIsRejected(): void
+    {
+        $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected', 'exists'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->method('exists')->willReturn(1);
+
+        $storage = new TokenStorage($this->makeConfig(), $redis);
+
+        $token = $storage->create(['sub' => 1]);
+
+        $this->assertNull($storage->load($token->getID()));
+    }
+
+    public function testDeleteBlacklistsTokenWithRemainingTtl(): void
+    {
+        $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected', 'setex'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->expects($this->once())->method('setex')->with(
+            $this->stringStartsWith('blacklist:jti:'),
+            $this->greaterThan(0),
+            '1',
+        );
+
+        $storage = new TokenStorage($this->makeConfig(), $redis);
+
+        $storage->delete($storage->create(['sub' => 1]));
+    }
+
+    public function testDeleteSkipsAlreadyExpiredToken(): void
+    {
+        $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected', 'setex'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->expects($this->never())->method('setex');
+
+        $storage = new TokenStorage($this->makeConfig(), $redis);
+
+        $token = $storage->create(['sub' => 1], (new \DateTimeImmutable())->sub(new \DateInterval('PT10S')));
+
+        $storage->delete($token);
+    }
+
+    public function testLoadFailsOpenWhenRedisUnavailable(): void
+    {
+        $storage = new TokenStorage($this->makeConfig(), $this->disconnectedRedis());
+
+        $token = $storage->create(['sub' => 1]);
+
+        $this->assertNotNull($storage->load($token->getID()));
+    }
+
+    public function testDeleteIsNoOpWhenRedisUnavailable(): void
+    {
+        $storage = new TokenStorage($this->makeConfig(), $this->disconnectedRedis());
+
+        $storage->delete($storage->create(['sub' => 1]));
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Covers the try/catch around exists() — a connected client can still drop mid-command,
+     * which testLoadFailsOpenWhenRedisUnavailable never reaches.
+     */
+    public function testLoadFailsOpenWhenRedisThrowsDuringBlacklistCheck(): void
+    {
+        $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected', 'exists'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->method('exists')->willThrowException(new \RedisException('connection lost'));
+
+        $storage = new TokenStorage($this->makeConfig(), $redis);
+
+        $token = $storage->create(['sub' => 1]);
+
+        $this->assertNotNull($storage->load($token->getID()));
+    }
+
+    /**
+     * Write-side equivalent of testLoadFailsOpenWhenRedisThrowsDuringBlacklistCheck, covering
+     * the try/catch around setex().
+     */
+    public function testDeleteSwallowsExceptionWhenRedisThrowsDuringBlacklistWrite(): void
+    {
+        $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected', 'setex'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->method('setex')->willThrowException(new \RedisException('connection lost'));
+
+        $storage = new TokenStorage($this->makeConfig(), $redis);
+
+        $storage->delete($storage->create(['sub' => 1]));
+
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/Feature/Auth/Jwt/TokenStorageTest.php
+++ b/tests/Feature/Auth/Jwt/TokenStorageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Auth\Jwt;
 
+use App\Auth\Jwt\Token;
 use App\Auth\Jwt\TokenStorage;
 use App\Config\JwtConfig;
 use Firebase\JWT\JWT;
@@ -194,6 +195,33 @@ class TokenStorageTest extends TestCase
         $this->assertNull($storage->load('not-a-jwt'));
     }
 
+    public function testTokenWithNonJsonHeaderIsRejected(): void
+    {
+        $storage = new TokenStorage($this->makeConfig(), $this->disconnectedRedis());
+
+        $malformed = JWT::urlsafeB64Encode('not-json-at-all') . '.' . JWT::urlsafeB64Encode('{}') . '.sig';
+
+        $this->assertNull($storage->load($malformed));
+    }
+
+    public function testTokenWithNonObjectHeaderIsRejected(): void
+    {
+        $storage = new TokenStorage($this->makeConfig(), $this->disconnectedRedis());
+
+        $malformed = JWT::urlsafeB64Encode('"just-a-string"') . '.' . JWT::urlsafeB64Encode('{}') . '.sig';
+
+        $this->assertNull($storage->load($malformed));
+    }
+
+    public function testTokenWithMissingAlgHeaderIsRejected(): void
+    {
+        $storage = new TokenStorage($this->makeConfig(), $this->disconnectedRedis());
+
+        $malformed = JWT::urlsafeB64Encode('{"typ":"JWT"}') . '.' . JWT::urlsafeB64Encode('{}') . '.sig';
+
+        $this->assertNull($storage->load($malformed));
+    }
+
     public function testBlacklistedTokenIsRejected(): void
     {
         $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected', 'exists'])->getMock();
@@ -220,6 +248,17 @@ class TokenStorageTest extends TestCase
         $storage = new TokenStorage($this->makeConfig(), $redis);
 
         $storage->delete($storage->create(['sub' => 1]));
+    }
+
+    public function testDeleteIsNoOpWhenTokenHasNoJti(): void
+    {
+        $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected', 'setex'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->expects($this->never())->method('setex');
+
+        $storage = new TokenStorage($this->makeConfig(), $redis);
+
+        $storage->delete(new Token('irrelevant', ['sub' => 1]));
     }
 
     public function testDeleteSkipsAlreadyExpiredToken(): void
@@ -268,6 +307,23 @@ class TokenStorageTest extends TestCase
         $token = $storage->create(['sub' => 1]);
 
         $this->assertNotNull($storage->load($token->getID()));
+    }
+
+    /**
+     * A token without a jti claim (e.g. issued before jti was added) must skip the blacklist
+     * lookup entirely rather than checking against an empty key.
+     */
+    public function testLoadSkipsBlacklistCheckWhenTokenHasNoJti(): void
+    {
+        $redis = $this->getMockBuilder(Redis::class)->onlyMethods(['isConnected', 'exists'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->expects($this->never())->method('exists');
+
+        $storage = new TokenStorage($this->makeConfig(), $redis);
+
+        $tokenWithoutJti = JWT::encode(['sub' => 1], self::HMAC_SECRET, 'HS256');
+
+        $this->assertNotNull($storage->load($tokenWithoutJti));
     }
 
     /**

--- a/tests/Feature/Bootloader/RedisUnavailableTest.php
+++ b/tests/Feature/Bootloader/RedisUnavailableTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Bootloader;
+
+use App\Config\RedisConfig;
+use App\Redis\ReconnectingRedis;
+use Psr\Log\LoggerInterface;
+use Redis;
+use Spiral\Testing\Attribute\Env;
+use Tests\DatabaseTransaction;
+use Tests\Factories\PasskeyFactory;
+use Tests\Factories\UserFactory;
+use Tests\Feature\Controller\PasskeyServiceMocker;
+use Tests\Fixtures;
+use Tests\TestCase;
+
+/**
+ * REDIS_CONNECTION='' (the default in every other test) short-circuits before ever attempting a
+ * connection, so these tests point it at a syntactically valid but unreachable address instead,
+ * to prove a Redis outage degrades every consumer gracefully instead of throwing during
+ * container resolution and breaking request handling app-wide.
+ */
+class RedisUnavailableTest extends TestCase implements DatabaseTransaction
+{
+    use PasskeyServiceMocker;
+
+    // Port 1: nothing listens there, so the OS refuses immediately instead of timing out.
+    private const string UNREACHABLE_CONNECTION = '127.0.0.1:1';
+
+    protected UserFactory $userFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userFactory = $this->getContainer()->get(UserFactory::class);
+    }
+
+    #[Env('REDIS_CONNECTION', self::UNREACHABLE_CONNECTION)]
+    public function testRedisSingletonDegradesToDisconnectedClientInsteadOfThrowing(): void
+    {
+        $redis = $this->getContainer()->get(Redis::class);
+
+        $this->assertInstanceOf(Redis::class, $redis);
+        $this->assertFalse($redis->isConnected());
+    }
+
+    #[Env('REDIS_CONNECTION', self::UNREACHABLE_CONNECTION)]
+    public function testUnauthenticatedJwksEndpointStillRespondsWhenRedisIsUnreachable(): void
+    {
+        // This route needs no Redis of its own, but AuthMiddleware constructs
+        // TokenStorageInterface as global middleware regardless; before the fix this 500'd
+        // purely from Redis being down.
+        $response = $this->get('/.well-known/jwks.json');
+
+        $response->assertOk();
+        $this->assertEquals(['keys' => []], $this->getJsonResponseBody($response));
+    }
+
+    #[Env('REDIS_CONNECTION', self::UNREACHABLE_CONNECTION)]
+    public function testAuthenticatedRequestFlowStillSucceedsWhenRedisIsUnreachable(): void
+    {
+        // Exercises the isConnected() === false guard in TokenStorage::load()/delete() against
+        // a real, disconnected, bootloader-resolved client (not a mock). The connected-but-
+        // throws path is covered separately by TokenStorageTest's mocked try/catch tests.
+        $auth = $this->makeAuth($this->userFactory->create());
+
+        $response = $this->withAuth($auth)->get('/profile');
+        $response->assertOk();
+
+        $response = $this->withAuth($auth)->post('/auth/logout');
+        $response->assertOk();
+    }
+
+    /**
+     * Unauthenticated (no Authorization header), so TokenStorage is not in play here —
+     * RateLimitMiddleware is this route's only other isConnected() caller. Proves the outage
+     * surfaces as a clean 503, and that PasskeyService's own guard degrades and recovers
+     * correctly on its own, independent of RateLimitMiddleware.
+     */
+    #[Env('REDIS_CONNECTION', self::UNREACHABLE_CONNECTION)]
+    public function testPasskeyLoginInitFailsCleanlyWhenRedisIsUnreachableThenSucceedsOnceRedisIsHealthyAgain(): void
+    {
+        $response = $this->get('/auth/login/passkey/init');
+
+        $response->assertStatus(503);
+        $body = $this->getJsonResponseBody($response);
+        $this->assertArrayHasKey('error', $body);
+        $this->assertArrayHasKey('message', $body);
+
+        // Simulates Redis recovering: 127.0.0.1:1 can't itself start accepting connections
+        // mid-test, so the singleton is swapped for a ReconnectingRedis pointed at the real
+        // test Redis instead of waiting out its own cooldown (that self-heal is proven
+        // separately, at the unit level, by ReconnectingRedisTest).
+        $this->getContainer()->bindSingleton(
+            Redis::class,
+            new ReconnectingRedis(
+                new RedisConfig([
+                    'connection' => 'localhost:6379',
+                    'timeout' => 1.0,
+                    'retry_interval' => 2,
+                    'retry_timeout' => 1.0,
+                    'prefix' => 'CT:testing:passkey-recovery:',
+                    'max_retries' => 1,
+                ]),
+                $this->getContainer()->get(LoggerInterface::class),
+            ),
+            force: true,
+        );
+
+        $response = $this->get('/auth/login/passkey/init');
+
+        $response->assertOk();
+        $body = $this->getJsonResponseBody($response);
+        $this->assertArrayHasKey('challenge', $body);
+        $this->assertNotEmpty($body['challenge']);
+    }
+
+    /**
+     * Covers PasskeyController::login() -> authenticate() -> getRequestOptions(), which asserts
+     * Redis availability before looking at $data, so arbitrary values reach the guard. Also
+     * unauthenticated, so TokenStorage is not in play here either.
+     */
+    #[Env('REDIS_CONNECTION', self::UNREACHABLE_CONNECTION)]
+    public function testPasskeyLoginFailsCleanlyWhenRedisIsUnreachable(): void
+    {
+        $response = $this->post('/auth/login/passkey', [
+            'challenge' => Fixtures::string(32),
+            'data' => Fixtures::string(32),
+        ]);
+
+        $response->assertStatus(503);
+        $body = $this->getJsonResponseBody($response);
+        $this->assertArrayHasKey('error', $body);
+        $this->assertArrayHasKey('message', $body);
+    }
+
+    /**
+     * Covers Profile\PasskeyController::init() -> PasskeyService::init(). This route requires
+     * auth, so TokenStorage::load() runs first and fails open (see
+     * testAuthenticatedRequestFlowStillSucceedsWhenRedisIsUnreachable()); PasskeyService's own
+     * guard then turns the outage into a 503.
+     */
+    #[Env('REDIS_CONNECTION', self::UNREACHABLE_CONNECTION)]
+    public function testProfilePasskeyInitFailsCleanlyWhenRedisIsUnreachable(): void
+    {
+        $auth = $this->makeAuth($this->userFactory->create());
+
+        $response = $this->withAuth($auth)->post('/profile/passkey/init', [
+            'name' => Fixtures::string(6),
+        ]);
+
+        $response->assertStatus(503);
+        $body = $this->getJsonResponseBody($response);
+        $this->assertArrayHasKey('error', $body);
+        $this->assertArrayHasKey('message', $body);
+    }
+
+    /**
+     * Covers Profile\PasskeyController::store() -> PasskeyService::store(). Unlike the other
+     * three tests here, $data must be a well-formed WebAuthn creation response, since store()
+     * deserializes it before ever touching Redis; makeCreateData() builds that shape.
+     */
+    #[Env('REDIS_CONNECTION', self::UNREACHABLE_CONNECTION)]
+    public function testProfilePasskeyStoreFailsCleanlyWhenRedisIsUnreachable(): void
+    {
+        $auth = $this->makeAuth($user = $this->userFactory->create());
+
+        $challenge = Fixtures::string(32);
+        $passkey = PasskeyFactory::make();
+        $options = $this->makeCreationChallengeOptions($challenge, $user);
+        $data = $this->makeCreateData($options, $passkey);
+
+        $response = $this->withAuth($auth)->post('/profile/passkey', [
+            'challenge' => $challenge,
+            'data' => $data,
+        ]);
+
+        $response->assertStatus(503);
+        $body = $this->getJsonResponseBody($response);
+        $this->assertArrayHasKey('error', $body);
+        $this->assertArrayHasKey('message', $body);
+    }
+}

--- a/tests/Feature/Config/JwtConfigTest.php
+++ b/tests/Feature/Config/JwtConfigTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Config;
+
+use App\Config\JwtConfig;
+use Tests\Fixtures;
+use Tests\TestCase;
+
+class JwtConfigTest extends TestCase
+{
+    public function testConfigs(): void
+    {
+        $config = $this->getContainer()->get(JwtConfig::class);
+
+        $class = new \ReflectionClass($config);
+        $class->getProperty('config')->setValue($config, [
+            'secret'           => Fixtures::string(),
+            'ttl'              => Fixtures::integer(1, 3600),
+            'refreshTtl'       => Fixtures::integer(1, 3600),
+            'publicKey'        => base64_encode(Fixtures::string()),
+            'privateKey'       => base64_encode(Fixtures::string()),
+            'issuer'           => Fixtures::url(),
+            'audience'         => Fixtures::url(),
+            'accessPublicKey'  => base64_encode(Fixtures::string()),
+            'accessPrivateKey' => base64_encode(Fixtures::string()),
+        ]);
+
+        $this->assertNotEmpty($config->getSecret());
+        $this->assertGreaterThan(0, $config->getTtl());
+        $this->assertGreaterThan(0, $config->getRefreshTtl());
+        $this->assertNotEmpty($config->getPublicKey());
+        $this->assertNotEmpty($config->getPrivateKey());
+        $this->assertNotEmpty($config->getIssuer());
+        $this->assertNotEmpty($config->getAudience());
+        $this->assertNotEmpty($config->getAccessPublicKey());
+        $this->assertNotEmpty($config->getAccessPrivateKey());
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{16}$/', $config->getAccessKeyId());
+    }
+
+    public function testGetAccessKeyIdIsEmptyWhenNoAccessPublicKeyIsConfigured(): void
+    {
+        $config = $this->getContainer()->get(JwtConfig::class);
+
+        $class = new \ReflectionClass($config);
+        $class->getProperty('config')->setValue($config, [
+            'accessPublicKey' => null,
+        ]);
+
+        $this->assertSame('', $config->getAccessKeyId());
+    }
+}

--- a/tests/Feature/Controller/Auth/JwksControllerTest.php
+++ b/tests/Feature/Controller/Auth/JwksControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controller\Auth;
+
+use Tests\TestCase;
+
+class JwksControllerTest extends TestCase
+{
+    public function testReturnsEmptyKeySetWhenAccessKeypairNotConfigured(): void
+    {
+        $response = $this->get('/.well-known/jwks.json');
+
+        $response->assertOk();
+
+        $this->assertEquals(['keys' => []], $this->getJsonResponseBody($response));
+    }
+
+    public function testDoesNotRequireAuthentication(): void
+    {
+        $response = $this->get('/.well-known/jwks.json');
+
+        $response->assertOk();
+    }
+}

--- a/tests/Feature/Controller/Auth/JwksControllerWithAccessKeypairTest.php
+++ b/tests/Feature/Controller/Auth/JwksControllerWithAccessKeypairTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controller\Auth;
+
+use Firebase\JWT\JWT;
+use Spiral\Config\ConfiguratorInterface;
+use Spiral\Config\Patch\Set;
+use Tests\TestCase;
+use Tests\Traits\ProvideRsaKeyPair;
+
+/**
+ * JwksControllerTest only covers the unconfigured (empty key set) path; this exercises the
+ * populated response over real HTTP with a configured RSA keypair.
+ *
+ * The keypair is generated at runtime (openssl_pkey_new), which PHP attributes can't express
+ * as a compile-time literal, so it's applied via beforeBooting()+Set rather than #[Env(...)].
+ */
+class JwksControllerWithAccessKeypairTest extends TestCase
+{
+    use ProvideRsaKeyPair;
+
+    private string $publicKeyPem;
+
+    protected function setUp(): void
+    {
+        $keyPair = $this->generateRsaKeyPair();
+        $this->publicKeyPem = $keyPair['publicKey'];
+
+        $this->beforeBooting(static function (ConfiguratorInterface $config) use ($keyPair): void {
+            $config->modify('jwt', new Set('accessPublicKey', base64_encode($keyPair['publicKey'])));
+            $config->modify('jwt', new Set('accessPrivateKey', base64_encode($keyPair['privateKey'])));
+        });
+
+        parent::setUp();
+    }
+
+    public function testReturnsPopulatedRfc7517KeySetOverHttp(): void
+    {
+        $response = $this->get('/.well-known/jwks.json');
+
+        $response->assertOk();
+
+        $body = $this->getJsonResponseBody($response);
+
+        $this->assertArrayHasKey('keys', $body);
+        $this->assertCount(1, $body['keys']);
+
+        $key = $body['keys'][0];
+
+        $this->assertEquals('RSA', $key['kty']);
+        $this->assertEquals('sig', $key['use']);
+        $this->assertEquals('RS256', $key['alg']);
+        $this->assertEquals(substr(hash('sha256', $this->publicKeyPem), 0, 16), $key['kid']);
+
+        foreach (['n', 'e'] as $field) {
+            $this->assertNotEmpty($key[$field]);
+            $this->assertStringNotContainsString('+', $key[$field], "{$field} must be base64url, not base64");
+            $this->assertStringNotContainsString('/', $key[$field], "{$field} must be base64url, not base64");
+            $this->assertStringNotContainsString('=', $key[$field], "{$field} must be unpadded base64url");
+        }
+
+        // Compare against the actual modulus/exponent, not just the string shape, to catch a
+        // regression that corrupts the value while keeping it non-empty and unpadded.
+        $publicKeyResource = openssl_pkey_get_public($this->publicKeyPem);
+        $this->assertNotFalse($publicKeyResource, 'Unable to load the test RSA public key.');
+
+        $details = openssl_pkey_get_details($publicKeyResource);
+        $this->assertIsArray($details);
+
+        $this->assertSame($details['rsa']['n'], JWT::urlsafeB64Decode($key['n']));
+        $this->assertSame($details['rsa']['e'], JWT::urlsafeB64Decode($key['e']));
+    }
+}

--- a/tests/Feature/Controller/Auth/LogoutControllerTest.php
+++ b/tests/Feature/Controller/Auth/LogoutControllerTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Controller\Auth;
 
+use Redis;
+use Spiral\Config\ConfiguratorInterface;
+use Spiral\Config\Patch\Set;
+use Spiral\Testing\Attribute\Env;
 use Tests\DatabaseTransaction;
 use Tests\Factories\UserFactory;
 use Tests\TestCase;
@@ -15,11 +19,39 @@ class LogoutControllerTest extends TestCase implements DatabaseTransaction
      */
     protected UserFactory $userFactory;
 
+    // Dedicated prefix so this file's guest-bucket increments don't collide with
+    // RateLimitMiddlewareTest's exact-count assertions under parallel test runs.
+    private const REDIS_PREFIX = 'CT:testing:logout:';
+
     protected function setUp(): void
     {
+        $this->beforeBooting(static function (ConfiguratorInterface $config): void {
+            $config->modify('redis', new Set('prefix', self::REDIS_PREFIX));
+        });
+
         parent::setUp();
 
         $this->userFactory = $this->getContainer()->get(UserFactory::class);
+    }
+
+    protected function tearDown(): void
+    {
+        /** @var Redis $redis */
+        $redis = $this->getContainer()->get(Redis::class);
+
+        if ($redis->isConnected()) {
+            $keys = $redis->keys('*');
+
+            if (is_array($keys) && $keys !== []) {
+                // del() re-applies OPT_PREFIX, so it must be stripped from keys() results first.
+                $redis->del(array_map(
+                    static fn(string $key): string => substr($key, strlen(self::REDIS_PREFIX)),
+                    $keys,
+                ));
+            }
+        }
+
+        parent::tearDown();
     }
 
     public function testWithoutAuth(): void
@@ -33,6 +65,7 @@ class LogoutControllerTest extends TestCase implements DatabaseTransaction
         $this->assertArrayHasKey('message', $body);
     }
 
+    #[Env('REDIS_CONNECTION', 'localhost:6379')]
     public function testLoggedOut(): void
     {
         $auth = $this->makeAuth($this->userFactory->create());
@@ -41,9 +74,12 @@ class LogoutControllerTest extends TestCase implements DatabaseTransaction
 
         $response->assertOk();
 
-        // TODO. Add checking to access protected endpoints once token blacklist implemented
+        $response = $this->withAuth($auth)->get('/profile');
+
+        $response->assertUnauthorized();
     }
 
+    #[Env('REDIS_CONNECTION', 'localhost:6379')]
     public function testLoggedOutClosesRefreshToken(): void
     {
         $auth = $this->makeAuth($this->userFactory->create());
@@ -54,9 +90,23 @@ class LogoutControllerTest extends TestCase implements DatabaseTransaction
 
         $response->assertOk();
 
-        // TODO. Add checking to access protected endpoints once token blacklist implemented
-        // TODO. Add checking to refresh once token blacklist implemented
+        $response = $this->withAuth($auth)->get('/profile');
+
+        $response->assertUnauthorized();
+
+        $response = $this->withAuthRefresh($auth)->post('/auth/refresh');
+
+        $response->assertUnauthorized();
     }
 
-    // TODO. Add checking to access protected endpoints once token blacklist implemented
+    public function testLoggedOutWithoutRealRedisDoesNotBreakLogout(): void
+    {
+        // REDIS_CONNECTION defaults to '' in tests: proves logout succeeds even when
+        // revocation can't be recorded.
+        $auth = $this->makeAuth($this->userFactory->create());
+
+        $response = $this->withAuth($auth)->post('/auth/logout');
+
+        $response->assertOk();
+    }
 }

--- a/tests/Feature/Controller/PasskeyServiceMocker.php
+++ b/tests/Feature/Controller/PasskeyServiceMocker.php
@@ -13,6 +13,7 @@ use App\Service\Auth\Passkey\PasskeyService;
 use Cycle\ORM\EntityManagerInterface;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Tests\Factories\PasskeyFactory;
 use Webauthn\PublicKeyCredentialParameters;
 use Webauthn\TrustPath\EmptyTrustPath;
@@ -24,6 +25,9 @@ trait PasskeyServiceMocker
         $redis = $this->getMockBuilder(\Redis::class)
                       ->disableOriginalConstructor()
                       ->getMock();
+        // Default to "connected" so existing tests keep exercising the happy path;
+        // RedisUnavailableTest-style tests override this to prove the outage path.
+        $redis->method('isConnected')->willReturn(true);
 
         $config = $this->getContainer()->get(PasskeyConfig::class);
 
@@ -33,9 +37,11 @@ trait PasskeyServiceMocker
 
         $userRepository = $this->getContainer()->get(UserRepository::class);
 
+        $logger = $this->getContainer()->get(LoggerInterface::class);
+
         $passkeyAuthService = $this->getMockBuilder(PasskeyService::class)
                                    ->setConstructorArgs([
-                                       $redis, $config, $tr, $repository, $userRepository,
+                                       $redis, $config, $tr, $repository, $userRepository, $logger,
                                    ])
                                    ->onlyMethods($methods)
                                    ->getMock();

--- a/tests/Feature/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/Feature/Middleware/RateLimitMiddlewareTest.php
@@ -35,7 +35,16 @@ class RateLimitMiddlewareTest extends TestCase
     {
         /** @var \Redis $redis */
         $redis = $this->getContainer()->get(\Redis::class);
-        $redis->del($redis->keys('CT:testing:*'));
+
+        $keys = $redis->keys('*');
+
+        if (is_array($keys) && $keys !== []) {
+            // del() re-applies OPT_PREFIX, so it must be stripped from keys() results first.
+            $redis->del(array_map(
+                static fn(string $key): string => substr($key, strlen('CT:testing:')),
+                $keys,
+            ));
+        }
 
         parent::tearDown();
     }

--- a/tests/Feature/Redis/ReconnectingRedisTest.php
+++ b/tests/Feature/Redis/ReconnectingRedisTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Redis;
+
+use App\Config\RedisConfig;
+use App\Redis\ReconnectingRedis;
+use Psr\Log\LoggerInterface;
+use ReflectionProperty;
+use Tests\TestCase;
+
+/**
+ * ReconnectingRedis is the state machine that lets the shared Redis::class singleton recover
+ * from a transient outage without a worker restart (see RedisBootloader). These tests exercise
+ * it directly rather than end-to-end, since Spiral\Testing\TestCase builds a fresh container
+ * per test method.
+ */
+class ReconnectingRedisTest extends TestCase
+{
+    // Nothing listens on port 1, so the OS refuses immediately instead of timing out.
+    private const string UNREACHABLE_CONNECTION = '127.0.0.1:1';
+
+    public function testNeverThrowsAndReportsDisconnectedWhenTargetIsUnreachable(): void
+    {
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $logger->expects($this->atLeastOnce())->method('emergency');
+
+        $redis = new ReconnectingRedis($this->config(self::UNREACHABLE_CONNECTION), $logger);
+
+        $this->assertFalse($redis->isConnected());
+    }
+
+    public function testDoesNotRetryOrLogAgainWithinTheCooldownWindow(): void
+    {
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        // The constructor makes the first attempt; two more calls within the cooldown must not
+        // trigger a second attempt or log.
+        $logger->expects($this->once())->method('emergency');
+
+        $redis = new ReconnectingRedis($this->config(self::UNREACHABLE_CONNECTION), $logger);
+
+        $this->assertFalse($redis->isConnected());
+        $this->assertFalse($redis->isConnected());
+    }
+
+    public function testRetriesAndLogsAgainOnceTheCooldownHasElapsed(): void
+    {
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        // Constructor = first attempt/log. Forcing the cooldown to elapse, then one more call,
+        // triggers a second attempt/log — proves it keeps retrying rather than staying stuck.
+        $logger->expects($this->exactly(2))->method('emergency');
+
+        $redis = new ReconnectingRedis($this->config(self::UNREACHABLE_CONNECTION), $logger);
+        $this->assertFalse($redis->isConnected());
+
+        $this->forceReconnectCooldownToHaveElapsed($redis);
+
+        $this->assertFalse($redis->isConnected());
+    }
+
+    public function testConnectsSuccessfullyAndStopsAttemptingOnceTargetIsReachable(): void
+    {
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $logger->expects($this->never())->method('emergency');
+
+        // Points at the real test Redis, proving a genuine connect/ping round trip, not a
+        // mocked-away "success."
+        $redis = new ReconnectingRedis($this->config('localhost:6379'), $logger);
+
+        $this->assertTrue($redis->isConnected());
+        // A second call must reuse the now-live connection, not attempt again.
+        $this->assertTrue($redis->isConnected());
+    }
+
+    public function testRedisSingletonResolvedFromContainerIsTheSameInstanceAcrossMultipleGets(): void
+    {
+        // Confirms the premise the fix depends on: Redis::class is cached, not rebuilt, across
+        // repeated resolutions from one container.
+        $first = $this->getContainer()->get(\Redis::class);
+        $second = $this->getContainer()->get(\Redis::class);
+
+        $this->assertSame($first, $second);
+    }
+
+    private function config(string $connection): RedisConfig
+    {
+        return new RedisConfig([
+            'connection' => $connection,
+            'timeout' => 1.0,
+            'retry_interval' => 2,
+            'retry_timeout' => 1.0,
+            'prefix' => 'CT:testing:reconnect:',
+            'max_retries' => 1,
+        ]);
+    }
+
+    private function forceReconnectCooldownToHaveElapsed(ReconnectingRedis $redis): void
+    {
+        $property = new ReflectionProperty(ReconnectingRedis::class, 'lastAttemptAt');
+        $property->setAccessible(true);
+        $property->setValue($redis, microtime(true) - 3600);
+    }
+}

--- a/tests/Feature/Service/Auth/JwksServiceTest.php
+++ b/tests/Feature/Service/Auth/JwksServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Service\Auth;
+
+use App\Config\JwtConfig;
+use App\Service\Auth\JwksService;
+use Tests\TestCase;
+use Tests\Traits\ProvideRsaKeyPair;
+
+class JwksServiceTest extends TestCase
+{
+    use ProvideRsaKeyPair;
+
+    public function testEmptyKeySetWhenAccessKeypairNotConfigured(): void
+    {
+        $config = $this->getMockBuilder(JwtConfig::class)->getMock();
+        $config->method('getAccessPublicKey')->willReturn('');
+
+        $service = new JwksService($config);
+
+        $this->assertEquals(['keys' => []], $service->getKeySet());
+    }
+
+    public function testReturnsRfc7517KeyWhenAccessKeypairConfigured(): void
+    {
+        $keyPair = $this->generateRsaKeyPair();
+
+        $config = $this->getMockBuilder(JwtConfig::class)->getMock();
+        $config->method('getAccessPublicKey')->willReturn($keyPair['publicKey']);
+        $config->method('getAccessKeyId')->willReturn('test-kid');
+
+        $service = new JwksService($config);
+        $keySet = $service->getKeySet();
+
+        $this->assertCount(1, $keySet['keys']);
+
+        $key = $keySet['keys'][0];
+
+        $this->assertEquals('RSA', $key['kty']);
+        $this->assertEquals('sig', $key['use']);
+        $this->assertEquals('RS256', $key['alg']);
+        $this->assertEquals('test-kid', $key['kid']);
+        $this->assertNotEmpty($key['n']);
+        $this->assertNotEmpty($key['e']);
+        $this->assertStringNotContainsString('+', $key['n'], 'n must be base64url, not base64');
+        $this->assertStringNotContainsString('=', $key['n'], 'n must be unpadded base64url');
+    }
+
+    public function testKeySetNeverExposesHmacSecret(): void
+    {
+        $config = $this->getMockBuilder(JwtConfig::class)->getMock();
+        $config->method('getAccessPublicKey')->willReturn('');
+        $config->method('getSecret')->willReturn('super-secret-hmac-key');
+
+        $service = new JwksService($config);
+
+        $this->assertEquals(['keys' => []], $service->getKeySet());
+    }
+}

--- a/tests/Feature/Service/Auth/JwksServiceTest.php
+++ b/tests/Feature/Service/Auth/JwksServiceTest.php
@@ -48,6 +48,33 @@ class JwksServiceTest extends TestCase
         $this->assertStringNotContainsString('=', $key['n'], 'n must be unpadded base64url');
     }
 
+    public function testEmptyKeySetWhenAccessPublicKeyIsNotValidPem(): void
+    {
+        $config = $this->getMockBuilder(JwtConfig::class)->getMock();
+        $config->method('getAccessPublicKey')->willReturn('not-a-valid-pem-key');
+
+        $service = new JwksService($config);
+
+        $this->assertEquals(['keys' => []], $service->getKeySet());
+    }
+
+    /**
+     * A valid PEM public key that isn't RSA (e.g. EC) parses fine but has no rsa.n/rsa.e
+     * details — must still fall back to an empty key set rather than error or emit garbage.
+     */
+    public function testEmptyKeySetWhenAccessPublicKeyIsNotRsa(): void
+    {
+        $ecKey = openssl_pkey_new(['private_key_type' => OPENSSL_KEYTYPE_EC, 'curve_name' => 'prime256v1']);
+        $ecPublicKey = openssl_pkey_get_details($ecKey)['key'];
+
+        $config = $this->getMockBuilder(JwtConfig::class)->getMock();
+        $config->method('getAccessPublicKey')->willReturn($ecPublicKey);
+
+        $service = new JwksService($config);
+
+        $this->assertEquals(['keys' => []], $service->getKeySet());
+    }
+
     public function testKeySetNeverExposesHmacSecret(): void
     {
         $config = $this->getMockBuilder(JwtConfig::class)->getMock();

--- a/tests/Feature/Service/Auth/Passkey/PasskeyServiceTest.php
+++ b/tests/Feature/Service/Auth/Passkey/PasskeyServiceTest.php
@@ -4,12 +4,27 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Service\Auth\Passkey;
 
+use App\Service\Auth\Passkey\Exception\PasskeyServiceUnavailableException;
+use PHPUnit\Framework\MockObject\MockObject;
+use Tests\DatabaseTransaction;
+use Tests\Factories\PasskeyFactory;
+use Tests\Factories\UserFactory;
 use Tests\Feature\Controller\PasskeyServiceMocker;
+use Tests\Fixtures;
 use Tests\TestCase;
 
-class PasskeyServiceTest extends TestCase
+class PasskeyServiceTest extends TestCase implements DatabaseTransaction
 {
     use PasskeyServiceMocker;
+
+    protected UserFactory $userFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userFactory = $this->getContainer()->get(UserFactory::class);
+    }
 
     public function testGenerateChallenge(): void
     {
@@ -18,5 +33,95 @@ class PasskeyServiceTest extends TestCase
         $data = $service->initAuth();
 
         $this->assertNotEmpty($data->jsonSerialize());
+    }
+
+    public function testInitAuthThrowsWhenRedisFailsToStoreRequestOptions(): void
+    {
+        $service = $this->makePasskeyAuthMock(
+            [],
+            function (\Redis|MockObject $redis) {
+                $redis->method('hMSet')->willThrowException(new \RuntimeException('connection lost'));
+            },
+        );
+
+        $this->expectException(PasskeyServiceUnavailableException::class);
+
+        $service->initAuth();
+    }
+
+    public function testInitThrowsWhenRedisFailsToStoreCreationOptions(): void
+    {
+        $user = $this->userFactory->create();
+
+        $service = $this->makePasskeyAuthMock(
+            [],
+            function (\Redis|MockObject $redis) {
+                $redis->method('hMSet')->willThrowException(new \RuntimeException('connection lost'));
+            },
+        );
+
+        $this->expectException(PasskeyServiceUnavailableException::class);
+
+        $service->init($user, 'My Key');
+    }
+
+    public function testAuthenticateThrowsWhenRedisFailsToLoadRequestOptions(): void
+    {
+        $service = $this->makePasskeyAuthMock(
+            [],
+            function (\Redis|MockObject $redis) {
+                $redis->method('hGetAll')->willThrowException(new \RuntimeException('connection lost'));
+            },
+        );
+
+        $this->expectException(PasskeyServiceUnavailableException::class);
+
+        $service->authenticate(Fixtures::string(32), Fixtures::string());
+    }
+
+    public function testStoreThrowsWhenRedisFailsToLoadCreationOptions(): void
+    {
+        $user = $this->userFactory->create();
+        $challenge = Fixtures::string(32);
+        $passkey = PasskeyFactory::make();
+        $options = $this->makeCreationChallengeOptions($challenge, $user);
+        $data = $this->makeCreateData($options, $passkey);
+
+        $service = $this->makePasskeyAuthMock(
+            [],
+            function (\Redis|MockObject $redis) {
+                $redis->method('hGetAll')->willThrowException(new \RuntimeException('connection lost'));
+            },
+        );
+
+        $this->expectException(PasskeyServiceUnavailableException::class);
+
+        $service->store($user, $challenge, $data);
+    }
+
+    public function testStoreThrowsWhenRedisFailsToForgetOptions(): void
+    {
+        $user = $this->userFactory->create();
+        $challenge = Fixtures::string(32);
+        $passkey = PasskeyFactory::make();
+        $options = $this->makeCreationChallengeOptions($challenge, $user);
+        $data = $this->makeCreateData($options, $passkey);
+
+        $service = $this->makePasskeyAuthMock(
+            [],
+            function (\Redis|MockObject $redis) use ($passkey, $challenge, $options) {
+                $key = "passkeys:challenge:{$challenge}";
+                $redis->method('hGetAll')->with($key)->willReturn([
+                    'name' => $passkey->name,
+                    'challenge' => $challenge,
+                    'options' => json_encode($options),
+                ]);
+                $redis->method('del')->willThrowException(new \RuntimeException('connection lost'));
+            },
+        );
+
+        $this->expectException(PasskeyServiceUnavailableException::class);
+
+        $service->store($user, $challenge, $data);
     }
 }

--- a/tests/Feature/Service/RateLimit/RedisRateLimitTest.php
+++ b/tests/Feature/Service/RateLimit/RedisRateLimitTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Service\RateLimit;
 
 use App\Service\RateLimit\GuestRule;
 use App\Service\RateLimit\RedisRateLimit;
+use Psr\Log\LoggerInterface;
 use Tests\TestCase;
 
 class RedisRateLimitTest extends TestCase
@@ -17,7 +18,7 @@ class RedisRateLimitTest extends TestCase
         $redis->method('incr')->willReturn(false);
         $redis->method('getLastError')->willReturn('unknown error');
 
-        $rateLimit = new RedisRateLimit($redis);
+        $rateLimit = new RedisRateLimit($redis, $this->getContainer()->get(LoggerInterface::class));
 
         $this->expectException(\RuntimeException::class);
 
@@ -32,7 +33,7 @@ class RedisRateLimitTest extends TestCase
         $redis->method('getLastError')->willReturn('unknown error');
         $redis->method('ttl')->willReturn(-1);
 
-        $rateLimit = new RedisRateLimit($redis);
+        $rateLimit = new RedisRateLimit($redis, $this->getContainer()->get(LoggerInterface::class));
 
         $this->expectException(\RuntimeException::class);
 
@@ -47,7 +48,7 @@ class RedisRateLimitTest extends TestCase
         $redis->method('getLastError')->willReturn('unknown error');
         $redis->method('ttl')->willReturn(false);
 
-        $rateLimit = new RedisRateLimit($redis);
+        $rateLimit = new RedisRateLimit($redis, $this->getContainer()->get(LoggerInterface::class));
 
         $this->expectException(\RuntimeException::class);
 
@@ -63,10 +64,81 @@ class RedisRateLimitTest extends TestCase
         $redis->method('ttl')->willReturn(-1);
         $redis->method('expire')->willReturn(false);
 
-        $rateLimit = new RedisRateLimit($redis);
+        $rateLimit = new RedisRateLimit($redis, $this->getContainer()->get(LoggerInterface::class));
 
         $this->expectException(\RuntimeException::class);
 
         $rateLimit->hit(new GuestRule());
+    }
+
+    /**
+     * Unlike TestCounterException et al above, these report isConnected() === true but make
+     * incr()/ttl()/expire() throw RedisException, proving hit() fails open rather than letting
+     * the exception reach RateLimitMiddleware uncaught.
+     */
+    public function testHitFailsOpenAndLogsWhenIncrThrows(): void
+    {
+        $redis = $this->getMockBuilder(\Redis::class)->onlyMethods(['isConnected', 'incr'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->method('incr')->willThrowException(new \RedisException('Connection lost'));
+
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $logger->expects($this->once())
+               ->method('error')
+               ->with(
+                   'Rate limiting is unavailable; failing open',
+                   $this->callback(function (array $context) {
+                       $this->assertEquals(\RedisException::class, $context['error']);
+                       $this->assertEquals('Connection lost', $context['message']);
+                       return true;
+                   }),
+               );
+
+        $rateLimit = new RedisRateLimit($redis, $logger);
+
+        $rule = new GuestRule();
+        $hit = $rateLimit->hit($rule);
+
+        $this->assertFalse($hit->isReached());
+        $this->assertEquals($rule->limit(), $hit->getRemaining());
+    }
+
+    public function testHitFailsOpenAndLogsWhenTtlThrows(): void
+    {
+        $redis = $this->getMockBuilder(\Redis::class)->onlyMethods(['isConnected', 'incr', 'ttl'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->method('incr')->willReturn(1);
+        $redis->method('ttl')->willThrowException(new \RedisException('Connection lost'));
+
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $logger->expects($this->once())->method('error');
+
+        $rateLimit = new RedisRateLimit($redis, $logger);
+
+        $rule = new GuestRule();
+        $hit = $rateLimit->hit($rule);
+
+        $this->assertFalse($hit->isReached());
+        $this->assertEquals($rule->limit(), $hit->getRemaining());
+    }
+
+    public function testHitFailsOpenAndLogsWhenExpireThrows(): void
+    {
+        $redis = $this->getMockBuilder(\Redis::class)->onlyMethods(['isConnected', 'incr', 'ttl', 'expire'])->getMock();
+        $redis->method('isConnected')->willReturn(true);
+        $redis->method('incr')->willReturn(1);
+        $redis->method('ttl')->willReturn(-1);
+        $redis->method('expire')->willThrowException(new \RedisException('Connection lost'));
+
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $logger->expects($this->once())->method('error');
+
+        $rateLimit = new RedisRateLimit($redis, $logger);
+
+        $rule = new GuestRule();
+        $hit = $rateLimit->hit($rule);
+
+        $this->assertFalse($hit->isReached());
+        $this->assertEquals($rule->limit(), $hit->getRemaining());
     }
 }

--- a/tests/Traits/ProvideRsaKeyPair.php
+++ b/tests/Traits/ProvideRsaKeyPair.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Traits;
+
+trait ProvideRsaKeyPair
+{
+    /**
+     * @return array{privateKey: string, publicKey: string}
+     */
+    protected function generateRsaKeyPair(): array
+    {
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        $this->assertNotFalse($resource, 'Unable to generate a test RSA keypair.');
+
+        openssl_pkey_export($resource, $privateKey);
+
+        $details = openssl_pkey_get_details($resource);
+
+        $this->assertIsArray($details);
+
+        return [
+            'privateKey' => $privateKey,
+            'publicKey' => $details['key'],
+        ];
+    }
+}


### PR DESCRIPTION
## Problem statement

Access tokens were effectively unrevocable. Logout deleted the refresh token but left the access token valid for its full TTL, so a stolen token kept working after the user signed out. Both access and refresh tokens were signed with the same shared HS256 secret, verification trusted the `alg` value in the token's own header (algorithm confusion), and issued tokens carried no `jti`, `iss` or `aud` claims — there was nothing to revoke against and nothing to pin the audience to.

A second class of problems surfaced while working on this: a Redis outage took the whole API down. `RedisBootloader` threw at boot, `RedisRateLimit` crashed when the socket dropped mid-request, and a worker that lost the connection never recovered without a restart.

## Changes

**Token hardening**
- Redis `jti` blacklist, written on token deletion and checked on load. Logout now invalidates the access token immediately.
- RS256 signing when an access keypair is provisioned, with an HS256 fallback so this deploys before the keys exist. See the deployment note for the provisioning sequence.
- Verification uses a fixed algorithm allow-list rather than the token's own header.
- Every issued token gets a random `jti` plus configurable `iss`/`aud`.
- `GET /auth/jwks` publishes the access public key (RFC 7517).

**Redis resilience**
- `ReconnectingRedis` lets a worker recover from an outage without a restart; `RedisBootloader` no longer throws.
- Auth and rate limiting fail open on an outage and log the gap; passkey endpoints return 503 instead of 500.
- Fixed the latent `RedisRateLimit` crash on a mid-request socket drop.

Deployment sequence and key provisioning: `docs/deployment/2026-08-07-jwt-access-token-hardening.md`.

## Verification

- `composer phpunit` — 846 tests, 4017 assertions, OK.
- `composer phpcs` — 246/246 clean. `composer psalm` — clean.
- New coverage: `TokenStorageTest` (revocation, alg allow-list, RS256/HS256 selection, jti/iss/aud claims), `RefreshTokenStorageTest`, `JwksControllerTest`, and `RedisUnavailableTest` which exercises the fail-open paths against a downed Redis.
- Independent review round completed with no material findings outstanding.
- The HS256 fallback path is covered by tests, so the branch is safe to deploy before the keypair exists.
