### PR TITLE
fix(api): reject gateway-owned headers on the direct-to-API path

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -104,3 +104,5 @@ JWT_ISSUER=https://api.cash-track.app
 JWT_AUDIENCE=https://api.cash-track.app
 ACCESS_TOKEN_PUBLIC_KEY="{rsa-public-key}" # base64 encoded, optional — falls back to HS256 with JWT_SECRET when empty
 ACCESS_TOKEN_PRIVATE_KEY="{rsa-private-key}" # base64 encoded, optional — falls back to HS256 with JWT_SECRET when empty
+
+GATEWAY_SECRET= # shared secret with gateway; empty disables the trust-boundary check

--- a/app/config/gateway.php
+++ b/app/config/gateway.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types = 1);
+
+return [
+    'secret' => env('GATEWAY_SECRET', ''),
+];

--- a/app/src/Auth/AuthMiddleware.php
+++ b/app/src/Auth/AuthMiddleware.php
@@ -47,7 +47,7 @@ final class AuthMiddleware implements MiddlewareInterface
         $this->trackActiveAt($actor);
 
         return $handler->handle(
-            $request->withAddedHeader(self::HEADER_USER_ID, (string) $actor->id)
+            $request->withHeader(self::HEADER_USER_ID, (string) $actor->id)
                     ->withAttribute(self::USER_LOCALE, $this->userOptionsService->getLocale($actor))
         );
     }

--- a/app/src/Bootloader/RoutesBootloader.php
+++ b/app/src/Bootloader/RoutesBootloader.php
@@ -6,6 +6,7 @@ namespace App\Bootloader;
 
 use App\Auth\AuthMiddleware;
 use App\Middleware\ApiVersionMiddleware;
+use App\Middleware\InternalHeadersMiddleware;
 use App\Middleware\LocaleSelectorMiddleware;
 use App\Middleware\RateLimitMiddleware;
 use App\Middleware\TraceContextMiddleware;
@@ -41,6 +42,8 @@ final class RoutesBootloader extends BaseRoutesBootloader
     protected function globalMiddleware(): array
     {
         return [
+            // Must precede auth and every group middleware.
+            InternalHeadersMiddleware::class,
             TraceContextMiddleware::class,
             LocaleSelectorMiddleware::class,
             ApiVersionMiddleware::class,

--- a/app/src/Config/GatewayConfig.php
+++ b/app/src/Config/GatewayConfig.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config;
+
+use Spiral\Core\InjectableConfig;
+
+class GatewayConfig extends InjectableConfig
+{
+    public const string CONFIG = 'gateway';
+
+    /**
+     * @internal For internal usage. Will be hydrated in the constructor.
+     */
+    protected array $config = [
+        'secret' => null,
+    ];
+
+    /** Sent by the gateway as X-Gateway-Secret; empty disables the check. */
+    public function getSecret(): string
+    {
+        return (string) $this->config['secret'];
+    }
+}

--- a/app/src/Middleware/InternalHeadersMiddleware.php
+++ b/app/src/Middleware/InternalHeadersMiddleware.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use App\Config\GatewayConfig;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * The API is publicly routable, so a request that skipped the gateway can forge the headers the
+ * gateway owns.
+ *
+ * IP headers are only rewritten once a secret is configured — without one the gateway is
+ * indistinguishable from an attacker, and rewriting would key every request on its address.
+ * REMOTE_ADDR replaces them rather than blanking, which would pool everyone into one bucket.
+ */
+final class InternalHeadersMiddleware implements MiddlewareInterface
+{
+    private const string HEADER_SECRET = 'X-Gateway-Secret';
+    private const string INTERNAL_HEADER_PREFIX = 'X-Internal-';
+
+    public function __construct(
+        private readonly GatewayConfig $config,
+    ) {
+    }
+
+    #[\Override]
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $secret = $this->config->getSecret();
+        $trusted = $secret !== '' && hash_equals($secret, $request->getHeaderLine(self::HEADER_SECRET));
+
+        $request = $this->stripInternalHeaders($request->withoutHeader(self::HEADER_SECRET));
+
+        if ($secret !== '' && ! $trusted) {
+            $request = $this->neutralizeIpHeaders($request);
+        }
+
+        return $handler->handle($request);
+    }
+
+    private function stripInternalHeaders(ServerRequestInterface $request): ServerRequestInterface
+    {
+        foreach (array_keys($request->getHeaders()) as $name) {
+            if (stripos($name, self::INTERNAL_HEADER_PREFIX) === 0) {
+                $request = $request->withoutHeader($name);
+            }
+        }
+
+        return $request;
+    }
+
+    private function neutralizeIpHeaders(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $remoteAddr = (string) ($request->getServerParams()['REMOTE_ADDR'] ?? '');
+
+        foreach (RateLimitMiddleware::IP_HEADERS as $header) {
+            $request = $request->withHeader($header, $remoteAddr);
+        }
+
+        return $request;
+    }
+}

--- a/app/src/Middleware/RateLimitMiddleware.php
+++ b/app/src/Middleware/RateLimitMiddleware.php
@@ -62,7 +62,7 @@ class RateLimitMiddleware implements MiddlewareInterface
             }
         }
 
-        return '';
+        return (string) ($request->getServerParams()['REMOTE_ADDR'] ?? '');
     }
 
     private function tooManyRequests(RateLimitHitInterface $hit): ResponseInterface

--- a/docs/deployment/2026-08-07-gateway-trust-boundary.md
+++ b/docs/deployment/2026-08-07-gateway-trust-boundary.md
@@ -1,0 +1,160 @@
+# Gateway → API trust boundary
+
+Stops clients from forging the headers only the gateway is supposed to set, by adding a
+shared `X-Gateway-Secret` between the two services. Spans three repos: `api`, `gateway`,
+`infra`.
+
+## TL;DR
+
+The code is safe to deploy on its own, in either order, with no secret configured. Do that
+first. Turning the secret on is a **separate, later step with a required ordering** — get it
+backwards and you take a production rate-limiting outage.
+
+Two things to know before you touch anything:
+
+1. **Create the 1Password field before the infra deploy.** The templates now reference
+   `op://cash-track-prod/common/GATEWAY_SECRET`. If that field does not exist, `op inject`
+   fails and the whole play aborts (it fails before shipping anything, so there is no partial
+   state — but the deploy does not go through).
+2. **Ansible restarts `api` before `gateway`.** Handlers run in definition order, and
+   `Restart api` is defined first in `roles/compose-render/handlers/main.yml`. On a deploy
+   that sets the secret in both env files at once, that ordering is exactly the broken state
+   described below, for as long as the two restarts take.
+
+## What changes the moment the code deploys
+
+This happens with `GATEWAY_SECRET` unset — i.e. immediately, on the plain code deploy:
+
+- Every `X-Internal-*` header arriving from a client is stripped before routing. The gateway
+  never sets these, so any that arrive are forged by definition.
+- `X-Gateway-Secret` is stripped before routing, always, in every branch.
+- `AuthMiddleware` now **overwrites** `X-Internal-UserId` instead of appending to it.
+- `RateLimitMiddleware::fetchIp()` falls back to `REMOTE_ADDR` when no IP header is present,
+  instead of returning an empty string.
+
+That alone closes the rate-limit bypass on unauthenticated routes (login / register /
+password reset), where a rotating forged `X-Internal-UserId` previously minted a fresh Redis
+bucket per request and switched the rule from `GuestRule` (100/60s) to `UserRule` (1000/60s).
+It also closes a 500 on five endpoints that a forged header could trigger.
+
+Client IP headers are **not** touched in this state. That part needs the secret.
+
+## The four states
+
+`GATEWAY_SECRET` exists independently on each side. Only three of the four combinations are
+safe.
+
+| API | Gateway | Result |
+|---|---|---|
+| unset | unset | **Safe.** Forged `X-Internal-*` stripped. IP headers passed through untouched. This is the state the code deploy lands in. |
+| unset | set | **Safe, no-op.** Gateway sends the header; API ignores it and strips it. Useful as a staging step. |
+| set | set, **same value** | **Full protection.** Gateway traffic trusted, its IP headers honoured. Anything reaching the API directly gets its IP headers rewritten to its real peer address. |
+| set | unset **or different value** | **Broken.** Every gateway request is untrusted, so its IP headers are rewritten to `REMOTE_ADDR` — which over the Compose network is the gateway container's own address. All traffic from all users collapses into one shared `guest:<gateway-ip>` bucket at 100 requests/60s. |
+
+That last row is the entire reason this document exists.
+
+## Recommended sequence
+
+### Step 0 — create the secret (before any deploy)
+
+```bash
+openssl rand -base64 32
+```
+
+Store it in 1Password as vault `cash-track-prod` → item `common` → field `GATEWAY_SECRET`.
+Any non-empty string works; it is compared with `hash_equals`, not parsed.
+
+Do this first regardless of which rollout you pick below — the infra templates reference the
+field, and `op inject` will fail the play without it.
+
+### Step 1 — deploy the code
+
+Deploy `api` and `gateway` in either order. Nothing is coordinated yet because neither side
+has the secret in its environment. Verify normal traffic before continuing.
+
+### Step 2 — turn the secret on
+
+Pick one of the two options.
+
+**Option A — two-pass deploy (zero window, recommended).**
+
+Because `set gateway / unset api` is a safe no-op, you can stage it:
+
+1. Comment out the `GATEWAY_SECRET` line in
+   `ansible/roles/compose-render/templates/api.env.tpl`, leaving the `gateway.env.tpl` one in
+   place. Deploy. Only the gateway restarts; it now sends the header and the API ignores it.
+2. Uncomment the API line. Deploy. Only the API's env file changed, so only the API restarts —
+   and the gateway is already sending the header, so it comes back up trusted immediately.
+
+**Option B — single deploy (accept a brief window).**
+
+Deploy the branch as-is. Both env files change, both handlers fire, and the API restarts
+first. Between the API coming back up with the secret configured and the gateway restarting
+with the secret to send, gateway traffic is untrusted and rate limiting is globally capped at
+100 requests/60s. The window is bounded by how long a `docker compose restart gateway` takes
+after the API restart completes — on the order of seconds — but during it, requests over that
+cap get a `429`.
+
+At current traffic this may well stay under the cap and be a non-event. It is your call;
+Option A removes the question entirely at the cost of one extra deploy.
+
+## Verifying it took effect
+
+Rate limiting is the observable signal, so read Redis directly rather than inferring from
+response headers:
+
+```bash
+docker compose exec redis redis-cli --scan --pattern 'CT:rate-limit:*'
+```
+
+**Correct (secret matching on both sides):** keys carry real client addresses, e.g.
+`CT:rate-limit:user:1-203.0.113.10`.
+
+**Broken (state four above):** every key is the gateway container's address, e.g. a single
+`CT:rate-limit:guest:172.18.0.7` climbing fast. If you see that, the two `GATEWAY_SECRET`
+values disagree — the fastest fix is to restart the gateway so it picks the value up, or
+unset it on the API to fall back to the safe passthrough state.
+
+Confirm the direct-to-API path is actually closed:
+
+```bash
+for i in $(seq 1 5); do
+  curl -s -o /dev/null -D - -X POST https://api.cash-track.app/auth/login \
+    -H 'Content-Type: application/json' \
+    -H "X-Internal-UserId: $RANDOM" \
+    -d '{"email":"nobody@example.com","password":"wrong"}' | grep -i 'x-ratelimit'
+done
+```
+
+`X-RateLimit-Limit` must read `100` (`GuestRule`) and `X-RateLimit-Remaining` must decrement
+across the loop. A limit of `1000`, or a counter that resets each iteration, means the forged
+header is still being honoured.
+
+## Also in this deploy
+
+`gateway.env.tpl` gains an explicit `TRUSTED_PROXIES` line set to the same RFC1918 + loopback
+value the Go code already defaults to. It is a no-op that makes an implicit default visible
+and tunable — the previous change that introduced the setting never added it to the template.
+It does change the rendered `gateway.env`, so it triggers a gateway restart on the first
+deploy after this branch.
+
+## Rollback
+
+Reverse the enabling order — **remove the secret from the API first**, then the gateway.
+Removing it from the gateway first puts you straight into the broken state.
+
+Rolling back the code itself is clean whether or not the secret was ever set: the middleware
+simply stops running, and the API returns to its prior behaviour of trusting whatever headers
+arrive. That reopens the rate-limit bypass, so treat a rollback as a reason to reapply.
+
+## What this does not fix
+
+The API is still publicly routed at `api.cash-track.app`
+(`infra/compose/compose.app.yml`, the `api` Traefik router), so requests can still reach it
+without passing through the gateway — this change makes those requests harmless rather than
+preventing them.
+
+The gateway reaches the API over the Compose network (`API_URL=http://api:8080`) and does not
+need that public router. Deleting it would close the surface at the edge instead of in
+application code. That is a separate change, and it needs confirming that nothing else depends
+on direct API access first.

--- a/tests/Feature/Controller/Profile/ProfileControllerTest.php
+++ b/tests/Feature/Controller/Profile/ProfileControllerTest.php
@@ -120,6 +120,30 @@ class ProfileControllerTest extends TestCase implements DatabaseTransaction
         $this->assertArrayHasKey('message', $body);
     }
 
+    /**
+     * Regression: a forged X-Internal-UserId header sent directly to the API (bypassing the
+     * gateway) must not leak into the auth-resolved header. Before the fix this appended to the
+     * real user id (e.g. "999999,42"), which crashed CheckNickNameRequest's int cast with a 500.
+     * The "own nickname passes" check only succeeds when $id resolves to exactly the JWT user's
+     * id, so a 200 here also proves the header wasn't left as the forged value.
+     */
+    public function testCheckNickNamePassForCurrentDespiteForgedInternalUserIdHeader(): void
+    {
+        $auth = $this->makeAuth($user = $this->userFactory->create());
+
+        $response = $this->withAuth($auth)->post('/profile/check/nick-name', [
+            'nickName' => $user->nickName,
+        ], [
+            'X-Internal-UserId' => '999999',
+        ]);
+
+        $response->assertOk();
+
+        $body = $this->getJsonResponseBody($response);
+
+        $this->assertArrayHasKey('message', $body);
+    }
+
     public function testCheckNickNameFailsForClaimed(): void
     {
         $existingUser = $this->userFactory->create();

--- a/tests/Feature/Middleware/InternalHeadersMiddlewareTest.php
+++ b/tests/Feature/Middleware/InternalHeadersMiddlewareTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Middleware;
+
+use App\Middleware\InternalHeadersMiddleware;
+use App\Middleware\RateLimitMiddleware;
+use Laminas\Diactoros\Response\JsonResponse;
+use Nyholm\Psr7\ServerRequest;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Spiral\Testing\Attribute\Env;
+use Tests\TestCase;
+
+class InternalHeadersMiddlewareTest extends TestCase
+{
+    private const array FORGED_HEADERS = [
+        'X-Gateway-Secret' => 'attacker-supplied',
+        'X-Internal-UserId' => '999',
+        'X-Internal-UserLocale' => 'fr',
+        'Cf-Original-Connecting-IP' => '198.51.100.1',
+        'X-Real-IP' => '198.51.100.2',
+        'X-Forwarded-For' => '198.51.100.3',
+    ];
+
+    private function capture(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $handler = $this->getMockBuilder(RequestHandlerInterface::class)->getMock();
+
+        $captured = null;
+        $handler->method('handle')->willReturnCallback(
+            static function (ServerRequestInterface $request) use (&$captured): ResponseInterface {
+                $captured = $request;
+
+                return new JsonResponse([], 200);
+            },
+        );
+
+        $middleware = $this->getContainer()->get(InternalHeadersMiddleware::class);
+        $middleware->process($request, $handler);
+
+        $this->assertInstanceOf(ServerRequestInterface::class, $captured);
+
+        return $captured;
+    }
+
+    public function testSecretUnsetStripsInternalHeadersAndLeavesIpHeadersAlone(): void
+    {
+        $request = new ServerRequest('GET', '/', self::FORGED_HEADERS, null, '1.1', ['REMOTE_ADDR' => '203.0.113.9']);
+
+        $downstream = $this->capture($request);
+
+        $this->assertSame('', $downstream->getHeaderLine('X-Gateway-Secret'));
+        $this->assertSame('', $downstream->getHeaderLine('X-Internal-UserId'));
+        $this->assertSame('', $downstream->getHeaderLine('X-Internal-UserLocale'));
+
+        // no secret configured: interim rollout state, IP headers pass through untouched
+        $this->assertSame('198.51.100.1', $downstream->getHeaderLine('Cf-Original-Connecting-IP'));
+        $this->assertSame('198.51.100.2', $downstream->getHeaderLine('X-Real-IP'));
+        $this->assertSame('198.51.100.3', $downstream->getHeaderLine('X-Forwarded-For'));
+    }
+
+    #[Env('GATEWAY_SECRET', 'top-secret')]
+    public function testSecretConfiguredAndMissingReplacesIpHeadersWithRemoteAddr(): void
+    {
+        $headers = self::FORGED_HEADERS;
+        unset($headers['X-Gateway-Secret']);
+
+        $request = new ServerRequest('GET', '/', $headers, null, '1.1', ['REMOTE_ADDR' => '203.0.113.9']);
+
+        $downstream = $this->capture($request);
+
+        $this->assertSame('', $downstream->getHeaderLine('X-Gateway-Secret'));
+        $this->assertSame('', $downstream->getHeaderLine('X-Internal-UserId'));
+        $this->assertSame('', $downstream->getHeaderLine('X-Internal-UserLocale'));
+
+        foreach (RateLimitMiddleware::IP_HEADERS as $header) {
+            $this->assertSame('203.0.113.9', $downstream->getHeaderLine($header), "Header {$header}");
+        }
+    }
+
+    #[Env('GATEWAY_SECRET', 'top-secret')]
+    public function testSecretConfiguredAndWrongReplacesIpHeadersWithRemoteAddr(): void
+    {
+        $headers = self::FORGED_HEADERS;
+        $headers['X-Gateway-Secret'] = 'wrong-secret';
+
+        $request = new ServerRequest('GET', '/', $headers, null, '1.1', ['REMOTE_ADDR' => '203.0.113.9']);
+
+        $downstream = $this->capture($request);
+
+        $this->assertSame('', $downstream->getHeaderLine('X-Gateway-Secret'));
+
+        foreach (RateLimitMiddleware::IP_HEADERS as $header) {
+            $this->assertSame('203.0.113.9', $downstream->getHeaderLine($header), "Header {$header}");
+        }
+    }
+
+    #[Env('GATEWAY_SECRET', 'top-secret')]
+    public function testSecretConfiguredAndCorrectLeavesIpHeadersUntouched(): void
+    {
+        $headers = self::FORGED_HEADERS;
+        $headers['X-Gateway-Secret'] = 'top-secret';
+
+        $request = new ServerRequest('GET', '/', $headers, null, '1.1', ['REMOTE_ADDR' => '203.0.113.9']);
+
+        $downstream = $this->capture($request);
+
+        // the secret header is stripped even when it matched — it must never reach a controller/filter
+        $this->assertSame('', $downstream->getHeaderLine('X-Gateway-Secret'));
+        $this->assertSame('', $downstream->getHeaderLine('X-Internal-UserId'));
+        $this->assertSame('', $downstream->getHeaderLine('X-Internal-UserLocale'));
+
+        $this->assertSame('198.51.100.1', $downstream->getHeaderLine('Cf-Original-Connecting-IP'));
+        $this->assertSame('198.51.100.2', $downstream->getHeaderLine('X-Real-IP'));
+        $this->assertSame('198.51.100.3', $downstream->getHeaderLine('X-Forwarded-For'));
+    }
+}

--- a/tests/Feature/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/Feature/Middleware/RateLimitMiddlewareTest.php
@@ -88,4 +88,50 @@ class RateLimitMiddlewareTest extends TestCase
         $this->assertEquals('0', $response->getHeaderLine('X-RateLimit-Remaining'));
         $this->assertEquals($rule->ttl(), $response->getHeaderLine('Retry-After'));
     }
+
+    public function testFetchIpFallsBackToRemoteAddrWhenNoIpHeaderPresent(): void
+    {
+        $remoteAddr = long2ip(Fixtures::integer());
+
+        $rateLimit = $this->getContainer()->get(RateLimitInterface::class);
+
+        $ruleFactory = $this->getMockBuilder(RuleFactory::class)->getMock();
+        $ruleFactory->method('getRule')->with('', $remoteAddr)->willReturn(new GuestRule(5));
+
+        $middleware = new RateLimitMiddleware($rateLimit, $ruleFactory);
+
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $request->method('getHeaderLine')->with('X-Internal-UserId')->willReturn('');
+        $request->method('getHeader')->willReturnMap([
+            ['Cf-Original-Connecting-IP', []],
+            ['X-Real-IP', []],
+            ['X-Forwarded-For', []],
+        ]);
+        $request->method('getServerParams')->willReturn(['REMOTE_ADDR' => $remoteAddr]);
+
+        $handler = $this->getMockBuilder(RequestHandlerInterface::class)->getMock();
+        $handler->method('handle')->willReturn(new JsonResponse([], 201));
+
+        $response = $middleware->process($request, $handler);
+
+        $this->assertEquals(201, $response->getStatusCode());
+    }
+
+    /**
+     * Regression (D1): a forged X-Internal-UserId sent directly to the API on an unauthenticated
+     * 'web'-group route must not upgrade the rate limit from GuestRule (100/60s, IP-keyed) to
+     * UserRule (1000/60s). InternalHeadersMiddleware strips the header globally before this
+     * group middleware ever sees it.
+     */
+    public function testWebGroupRateLimitUnaffectedByForgedInternalUserIdHeader(): void
+    {
+        $response = $this->post('/auth/register/check/nick-name', [
+            'nickName' => Fixtures::string(),
+        ], [
+            'X-Internal-UserId' => '999999',
+        ]);
+
+        $response->assertOk();
+        $response->assertHasHeader('X-RateLimit-Limit', '100');
+    }
 }


### PR DESCRIPTION
> Stacked on #212 — review that one first. Diff against `feat/harden-jwt-access-tokens`.

## Problem statement

The API is publicly routed at `api.${DOMAIN}` through Traefik, so a client can reach it directly and skip the gateway entirely. On that path it accepted the headers the gateway owns as if the gateway had set them. Four distinct defects, all reachable from the internet:

1. **Rate-limit bypass (the serious one).** `GroupRegistry::$defaultGroup` is `web`, and the `web` group runs `RateLimitMiddleware` with **no** `AuthMiddleware`. A client-supplied `X-Internal-UserId` therefore selected `UserRule` (1000/60s) over `GuestRule` (100/60s) *and* keyed the bucket on the forged value. Rotating the header per request disabled brute-force protection on login, register and password reset.
2. `AuthMiddleware` used `withAddedHeader`, which appends. A forged `999` against a real session produced `"999,<realId>"` from `getHeaderLine()`.
3. The three IP headers `RateLimitMiddleware` reads are client-settable on the direct path.
4. Five filters bind `#[Header] public int`. A comma-joined or non-numeric value throws a `TypeError` in the caster — a trivial 500.

Worth correcting the TODO's framing: these headers are **not** used as the authenticated identity, and defect 2 does not give privilege escalation. `ReflectionProperty::setValue` on a `public int` coerces `"42"` to `int(42)` but throws on `"999,42"`, so the filters fail closed. The reachable impact is the rate-limit bypass plus a 500 DoS.

## Changes

- New `InternalHeadersMiddleware`, registered as the **first** global middleware so it runs before auth and before every group's middleware. It strips the `X-Gateway-Secret` header and every `X-Internal-*` header from the incoming request unconditionally.
- When `GATEWAY_SECRET` is configured and the request did not present it, the three IP headers are rewritten to `REMOTE_ADDR` rather than blanked — blanking would pool every direct caller into one shared bucket.
- IP rewriting is deliberately gated on a secret being configured. Without one, a gateway request is indistinguishable from an attacker's, and rewriting would key all gateway traffic on the gateway's own container address.
- `AuthMiddleware` now uses `withHeader` instead of `withAddedHeader`, so a forged value is replaced rather than appended to.
- `RateLimitMiddleware::fetchIp()` falls back to `REMOTE_ADDR`.
- New `GatewayConfig` + `app/config/gateway.php` reading `GATEWAY_SECRET`.

Rollout, including the ordering hazard between the two services, is documented in `docs/deployment/2026-08-07-gateway-trust-boundary.md`.

## Verification

- `composer phpunit` — 846 tests, 4017 assertions, OK. `phpcs` 246/246 clean, `psalm` clean.
- New `InternalHeadersMiddlewareTest` covers all four states of the secret matrix (unset, set+correct, set+absent, set+mismatched), plus two new `RateLimitMiddlewareTest` cases and a regression test on `ProfileControllerTest` proving a forged `X-Internal-UserId` cannot influence the authenticated actor.
- Verified against a live stack, not just unit tests: 100 direct-to-API `POST /auth/login` requests, each with a fresh random `X-Internal-UserId`, held the limit at 100, decremented monotonically 99→0, returned 429 on request 100, and produced a **single** `CT:rate-limit:guest:127.0.0.1` key. Before the fix each request got its own bucket.
- Also verified live: with the secret configured, three spoofed `X-Forwarded-For` values sent *without* the secret collapsed to one bucket; the same three sent *with* the correct secret produced three separate keys. A deliberate secret mismatch correctly collapsed to `REMOTE_ADDR`.
- Independent review round completed with no material findings outstanding.

## Follow-up not in this PR

The stronger fix is removing the public `api.${DOMAIN}` Traefik router entirely — the gateway reaches the API over the Compose network at `http://api:8080` and does not need it. That is an infra decision and is left out deliberately; this PR makes the API safe *while* it stays publicly routed.
