### PR TITLE
fix(api): log swallowed active_at tracking exception in AuthMiddleware

### DIFF
--- a/app/src/Auth/AuthMiddleware.php
+++ b/app/src/Auth/AuthMiddleware.php
@@ -12,6 +12,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
 use Spiral\Auth\AuthContextInterface;
 use Spiral\Auth\Middleware\AuthMiddleware as Framework;
 use Spiral\Translator\Traits\TranslatorTrait;
@@ -26,6 +27,7 @@ final class AuthMiddleware implements MiddlewareInterface
     public function __construct(
         private readonly UserService $userService,
         private readonly UserOptionsService $userOptionsService,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -65,7 +67,12 @@ final class AuthMiddleware implements MiddlewareInterface
 
         try {
             $this->userService->store($user);
-        } catch (\Throwable) {
+        } catch (\Throwable $exception) {
+            $this->logger->error('Failed to update user active_at', [
+                'userId' => $user->id,
+                'error' => get_class($exception),
+                'message' => $exception->getMessage(),
+            ]);
         }
     }
 }

--- a/tests/Feature/Auth/AuthMiddlewareTest.php
+++ b/tests/Feature/Auth/AuthMiddlewareTest.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace Tests\Feature\Auth;
 
 use App\Auth\AuthMiddleware;
+use App\Service\UserService;
+use Laminas\Diactoros\Response\JsonResponse;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+use Spiral\Auth\AuthContextInterface;
 use Spiral\Auth\Middleware\AuthMiddleware as Framework;
+use Tests\Factories\UserFactory;
 use Tests\TestCase;
 
 class AuthMiddlewareTest extends TestCase
@@ -23,5 +29,46 @@ class AuthMiddlewareTest extends TestCase
         $response = $middleware->process($request, $handler);
 
         $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testProcessLogsAndContinuesWhenActiveAtTrackingFails(): void
+    {
+        $user = UserFactory::make();
+        $user->id = 42;
+
+        $authContext = $this->getMockBuilder(AuthContextInterface::class)->getMock();
+        $authContext->method('getActor')->willReturn($user);
+
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $request->method('getAttribute')->with(Framework::ATTRIBUTE)->willReturn($authContext);
+        $request->method('withHeader')->willReturnSelf();
+        $request->method('withAttribute')->willReturnSelf();
+
+        $handler = $this->getMockBuilder(RequestHandlerInterface::class)->getMock();
+        $handler->method('handle')->willReturn(new JsonResponse([], 200));
+
+        $this->mock(UserService::class, ['store'], function (MockObject $mock) {
+            $mock->method('store')->willThrowException(new \RuntimeException('db down'));
+        });
+
+        $this->mock(LoggerInterface::class, [], function (MockObject $mock) {
+            $mock->expects($this->once())
+                 ->method('error')
+                 ->with(
+                     'Failed to update user active_at',
+                     $this->callback(function (array $context) {
+                         $this->assertEquals(42, $context['userId']);
+                         $this->assertEquals(\RuntimeException::class, $context['error']);
+                         $this->assertEquals('db down', $context['message']);
+
+                         return true;
+                     }),
+                 );
+        });
+
+        $middleware = $this->getContainer()->get(AuthMiddleware::class);
+        $response = $middleware->process($request, $handler);
+
+        $this->assertEquals(200, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
> Stacked on #215 — review that one first. Diff against `feat/auth-endpoint-rate-limits`.

## Problem

`AuthMiddleware::trackActiveAt()` wraps the `activeAt` DB write on every authenticated request in `catch (\Throwable) {}` — completely silent. A broken write (bad connection, schema drift, whatever) would fail on every request forever with zero trace in the logs.

## Changes

- Constructor-inject `Psr\Log\LoggerInterface` (Spiral auto-wires it, same as `RedisRateLimit` and `LoginBackoffService`)
- Catch block now logs at `error` level with `userId`, exception class, and exception message, matching the fail-open logging convention already used elsewhere in the codebase
- Still fails open — a logging/tracking failure must never block the actual authenticated request

## Verification

- `composer phpunit`: 896 tests, 4283 assertions, green
- `composer phpcs`: 249/249, 0 errors
- `composer psalm`: 0 errors
- 2 review rounds: round 1 flagged wrong log level (`warning` → `error` to match codebase precedent) and non-standard test mocking (switched to the project's `$this->mock()` helper); round 2 clean
- Live testing: exercised the real HTTP path (not just the mocked unit test) confirming the happy path still updates `active_at`, a forced `store()` failure still returns 200 and logs, and a mutation check (temporarily reverting the fix) proved the new test isn't vacuous

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UfGgXmArQz3h1kDC19xNqH