### PR TITLE
feat(api): inject trace_id into every Monolog log record

### DIFF
--- a/app/config/monolog.php
+++ b/app/config/monolog.php
@@ -2,9 +2,26 @@
 
 declare(strict_types=1);
 
+use App\Bootloader\LoggingBootloader;
+use App\Logging\TraceIdProcessor;
+use Cycle\Database\Driver\MySQL\MySQLDriver;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\RotatingFileHandler;
 use Monolog\Handler\SyslogHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
+use Spiral\Http\Middleware\ErrorHandlerMiddleware;
+
+// Spiral's 'log.rotate' handler alias applies Spiral\Monolog\Bootloader\MonologBootloader::DEFAULT_FORMAT,
+// which has no %extra% placeholder — trace_id (written to extra by TraceIdProcessor) would be silently
+// dropped from app.log. Build the handler directly with an explicit format that includes it, shared with
+// LoggingBootloader's own rotating file handlers via LoggingBootloader::LOG_FORMAT.
+$appLogHandler = new RotatingFileHandler(
+    filename: directory('runtime').'logs/app.log',
+    level: Logger::DEBUG,
+    useLocking: true,
+);
+$appLogHandler->setFormatter(new LineFormatter(LoggingBootloader::LOG_FORMAT));
 
 return [
 
@@ -20,13 +37,7 @@ return [
      */
     'handlers' => [
         'default' => [
-            [
-                'class' => 'log.rotate',
-                'options' => [
-                    'filename' => directory('runtime').'logs/app.log',
-                    'level' => Logger::DEBUG,
-                ],
-            ],
+            $appLogHandler,
         ],
         'stderr' => [
             \Monolog\Handler\ErrorLogHandler::class,
@@ -50,6 +61,11 @@ return [
     'processors' => [
         'default' => [
             \Spiral\Telemetry\Monolog\TelemetryProcessor::class,
+            TraceIdProcessor::class,
+        ],
+        'stderr' => [
+            PsrLogMessageProcessor::class,
+            TraceIdProcessor::class,
         ],
         'stdout' => [
             [
@@ -58,6 +74,24 @@ return [
                     'dateFormat' => 'Y-m-d\TH:i:s.uP',
                 ],
             ],
+            TraceIdProcessor::class,
+        ],
+        ErrorHandlerMiddleware::class => [
+            PsrLogMessageProcessor::class,
+            TraceIdProcessor::class,
+        ],
+        MySQLDriver::class => [
+            PsrLogMessageProcessor::class,
+            TraceIdProcessor::class,
+        ],
+        // Selected as the default channel in production via MONOLOG_DEFAULT_CHANNEL
+        // (see infra/ansible/roles/compose-render/templates/api.env.tpl); registered by
+        // Spiral\RoadRunnerBridge\Bootloader\LoggerBootloader, which only adds a handler,
+        // not a processor — this channel would otherwise fall back to the implicit
+        // PsrLogMessageProcessor-only default.
+        'roadrunner' => [
+            PsrLogMessageProcessor::class,
+            TraceIdProcessor::class,
         ],
     ],
 ];

--- a/app/src/Bootloader/LoggingBootloader.php
+++ b/app/src/Bootloader/LoggingBootloader.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Bootloader;
 
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\FormattableHandlerInterface;
+use Monolog\Handler\HandlerInterface;
 use Monolog\Level;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Http\Middleware\ErrorHandlerMiddleware;
@@ -20,6 +23,14 @@ final class LoggingBootloader extends Bootloader
      */
     const string DEFAULT_CHANNEL = 'default';
 
+    /**
+     * MonologBootloader::logRotate()'s own default format has no %extra% placeholder, which
+     * would silently drop trace_id (written there by App\Logging\TraceIdProcessor). Applied to
+     * every rotating file handler below via withTraceableFormat(), and reused by
+     * app/config/monolog.php for the app.log handler so both stay in sync.
+     */
+    public const string LOG_FORMAT = "[%datetime%] %level_name%: %message% %context% %extra%\n";
+
     public function init(MonologBootloader $monolog, EnvironmentInterface $env): void
     {
         $this->configureCommonHandlers($monolog);
@@ -34,20 +45,20 @@ final class LoggingBootloader extends Bootloader
         // app level errors
         $monolog->addHandler(
             channel: self::DEFAULT_CHANNEL,
-            handler: $monolog->logRotate(
+            handler: $this->withTraceableFormat($monolog->logRotate(
                 filename: directory('runtime') . 'logs/error.log',
                 level: Level::Error,
                 maxFiles: 25,
                 bubble: false
-            )
+            ))
         );
 
         // http level errors
         $monolog->addHandler(
             channel: ErrorHandlerMiddleware::class,
-            handler: $monolog->logRotate(
+            handler: $this->withTraceableFormat($monolog->logRotate(
                 filename: directory('runtime') . 'logs/http.log'
-            )
+            ))
         );
     }
 
@@ -56,17 +67,32 @@ final class LoggingBootloader extends Bootloader
         // debug and info messages via global LoggerInterface
         $monolog->addHandler(
             channel: self::DEFAULT_CHANNEL,
-            handler: $monolog->logRotate(
+            handler: $this->withTraceableFormat($monolog->logRotate(
                 filename: directory('runtime') . 'logs/debug.log'
-            )
+            ))
         );
 
         // debug database queries
         $monolog->addHandler(
             channel: MySQLDriver::class,
-            handler: $monolog->logRotate(
+            handler: $this->withTraceableFormat($monolog->logRotate(
                 filename: directory('runtime') . 'logs/db.log'
-            )
+            ))
         );
+    }
+
+    /**
+     * Overrides the formatter MonologBootloader::logRotate() already applied, so trace_id
+     * survives into these rotating log files. The handlers logRotate() returns are always
+     * FormattableHandlerInterface in practice; the instanceof guard keeps this safe against
+     * its HandlerInterface return type without assuming the concrete class.
+     */
+    private function withTraceableFormat(HandlerInterface $handler): HandlerInterface
+    {
+        if ($handler instanceof FormattableHandlerInterface) {
+            return $handler->setFormatter(new LineFormatter(self::LOG_FORMAT));
+        }
+
+        return $handler;
     }
 }

--- a/app/src/Logging/TraceIdProcessor.php
+++ b/app/src/Logging/TraceIdProcessor.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Logging;
+
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+use OpenTelemetry\API\Trace\Span;
+
+/**
+ * Injects the active OpenTelemetry span's trace_id into every log record.
+ *
+ * Reads the SDK's real active span directly instead of Spiral's TracerInterface
+ * wrapper, whose default binding resolves a fresh Tracer instance per call and
+ * never sees the activated span (see vendor/spiral/otel-bridge Tracer::getContext()).
+ */
+final class TraceIdProcessor implements ProcessorInterface
+{
+    /**
+     * ProcessorInterface only declares `@return LogRecord` in its docblock (no enforced return
+     * type), but the defensive array-record branch below must be able to return array too —
+     * matching the same LogRecord|array widening the vendor TelemetryProcessor uses.
+     *
+     * @psalm-suppress InvalidReturnType
+     * @psalm-suppress InvalidReturnStatement
+     */
+    #[\Override]
+    public function __invoke(LogRecord|array $record): array|LogRecord
+    {
+        $context = Span::getCurrent()->getContext();
+
+        if (!$context->isValid()) {
+            return $record;
+        }
+
+        if ($record instanceof LogRecord) {
+            $record->extra['trace_id'] = $context->getTraceId();
+
+            return $record;
+        }
+
+        $record['extra']['trace_id'] = $context->getTraceId();
+
+        return $record;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "kreait/firebase-php": "^8.0",
         "laminas/laminas-diactoros": "^3.5",
         "lcobucci/jwt": "^5.5",
+        "open-telemetry/api": "^1.7",
         "open-telemetry/exporter-otlp": "^1.2",
         "open-telemetry/transport-grpc": "^1.1",
         "phpdocumentor/reflection-docblock": "^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -15630,16 +15630,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -15705,7 +15705,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/var-dumper",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35c36d83512e187a152dd8e4e4fdd080",
+    "content-hash": "6f71a331e2b785b8c08bde412e1d3174",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2057,12 +2057,12 @@
             "version": "v7.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
+                "url": "https://github.com/googleapis/php-jwt.git",
                 "reference": "28aa0694bcfdfa5e2959c394d5a1ee7a5083629e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
                 "reference": "28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
                 "shasum": ""
             },

--- a/tests/Feature/Bootloader/LoggingBootloaderTest.php
+++ b/tests/Feature/Bootloader/LoggingBootloaderTest.php
@@ -15,11 +15,16 @@ class LoggingBootloaderTest extends TestCase
 {
     public function testDebugConfig(): void
     {
+        // willReturnMap can't express "return whatever default was passed", and its rows are
+        // matched by == against literal arguments, so $this->anything() as a row value never
+        // matches — a callback is the only reliable way to stub both DEBUG and MONOLOG_FORMAT.
         $env = $this->getMockBuilder(EnvironmentInterface::class)->getMock();
-        $env->expects($this->exactly(3))->method('get')->willReturnMap([
-            ['MONOLOG_FORMAT', $this->anything(), $this->returnArgument(2)],
-            ['DEBUG', $this->anything(), true],
-        ]);
+        $env->expects($this->exactly(5))->method('get')->willReturnCallback(
+            static fn (string $name, mixed $default = null): mixed => match ($name) {
+                'DEBUG' => true,
+                default => $default,
+            },
+        );
 
         $config = $this->getMockBuilder(ConfiguratorInterface::class)->getMock();
 

--- a/tests/Feature/Controller/Auth/LoginBackoffTest.php
+++ b/tests/Feature/Controller/Auth/LoginBackoffTest.php
@@ -77,6 +77,26 @@ class LoginBackoffTest extends TestCase implements DatabaseTransaction
         ]);
     }
 
+    /**
+     * Retry-After is `until - time()`, both whole-second unix timestamps captured a few
+     * milliseconds apart (the deadline is written during one request and read during the
+     * next). If that gap straddles a second boundary, truncation under-reports the delay by
+     * exactly one second — it can never over-report, so $expectedSeconds - 1 is the only other
+     * valid reading, not a flake to paper over with a wider tolerance.
+     */
+    private function assertRetryAfterCloseTo(TestResponse $response, int $expectedSeconds): void
+    {
+        $response->assertHasHeader('Retry-After');
+
+        $actual = (int) $response->getOriginalResponse()->getHeaderLine('Retry-After');
+
+        $this->assertContains(
+            $actual,
+            [$expectedSeconds - 1, $expectedSeconds],
+            "Retry-After was [$actual], expected [$expectedSeconds] (or one less due to time() truncation).",
+        );
+    }
+
     public function testFailedLoginsIncrementAttemptsAndSuccessResetsState(): void
     {
         /** @var \Redis $redis */
@@ -115,7 +135,7 @@ class LoginBackoffTest extends TestCase implements DatabaseTransaction
         $response = $this->attemptLogin($user->email, Fixtures::string());
 
         $response->assertStatus(429);
-        $response->assertHasHeader('Retry-After', '2');
+        $this->assertRetryAfterCloseTo($response, 2);
 
         // The throttled request is rejected before AuthService::login() ever runs, so it must
         // not count as an additional failure.
@@ -147,7 +167,7 @@ class LoginBackoffTest extends TestCase implements DatabaseTransaction
 
         $blocked = $this->attemptLogin($user->email, Fixtures::string());
         $blocked->assertStatus(429);
-        $blocked->assertHasHeader('Retry-After', '2');
+        $this->assertRetryAfterCloseTo($blocked, 2);
 
         sleep(3);
 
@@ -158,7 +178,7 @@ class LoginBackoffTest extends TestCase implements DatabaseTransaction
         // The delay must have grown from 2s to 4s — proof it is not frozen at its first value.
         $blockedAgain = $this->attemptLogin($user->email, Fixtures::string());
         $blockedAgain->assertStatus(429);
-        $blockedAgain->assertHasHeader('Retry-After', '4');
+        $this->assertRetryAfterCloseTo($blockedAgain, 4);
 
         // Wait out the grown window, then submit the correct password.
         sleep(5);
@@ -189,7 +209,7 @@ class LoginBackoffTest extends TestCase implements DatabaseTransaction
         $response = $this->attemptLogin($user->email, UserFactory::DEFAULT_PASSWORD);
 
         $response->assertStatus(429);
-        $response->assertHasHeader('Retry-After', '60');
+        $this->assertRetryAfterCloseTo($response, 60);
     }
 
     public function testDifferentEmailsHaveIndependentCounters(): void
@@ -233,7 +253,7 @@ class LoginBackoffTest extends TestCase implements DatabaseTransaction
 
         $realBlocked->assertStatus(429);
         $fakeBlocked->assertStatus(429);
-        $realBlocked->assertHasHeader('Retry-After', '2');
-        $fakeBlocked->assertHasHeader('Retry-After', '2');
+        $this->assertRetryAfterCloseTo($realBlocked, 2);
+        $this->assertRetryAfterCloseTo($fakeBlocked, 2);
     }
 }

--- a/tests/Unit/Logging/TraceIdProcessorTest.php
+++ b/tests/Unit/Logging/TraceIdProcessorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Logging;
+
+use App\Logging\TraceIdProcessor;
+use Monolog\Level;
+use Monolog\LogRecord;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\SpanContext;
+use Tests\TestCase;
+
+class TraceIdProcessorTest extends TestCase
+{
+    public function testLeavesExtraUntouchedWhenNoActiveSpan(): void
+    {
+        $processor = new TraceIdProcessor();
+
+        $record = $processor->__invoke($this->makeRecord());
+
+        $this->assertArrayNotHasKey('trace_id', $record->extra);
+    }
+
+    public function testAddsTraceIdWhenSpanIsActive(): void
+    {
+        $context = SpanContext::create(str_repeat('a', 32), str_repeat('b', 16));
+        $scope = Span::wrap($context)->activate();
+
+        try {
+            $processor = new TraceIdProcessor();
+
+            $record = $processor->__invoke($this->makeRecord());
+
+            $this->assertSame(str_repeat('a', 32), $record->extra['trace_id']);
+        } finally {
+            $scope->detach();
+        }
+    }
+
+    public function testLeavesArrayRecordExtraUntouchedWhenNoActiveSpan(): void
+    {
+        $processor = new TraceIdProcessor();
+
+        $record = $processor->__invoke($this->makeArrayRecord());
+
+        $this->assertArrayNotHasKey('trace_id', $record['extra']);
+    }
+
+    public function testAddsTraceIdToArrayRecordWhenSpanIsActive(): void
+    {
+        $context = SpanContext::create(str_repeat('a', 32), str_repeat('b', 16));
+        $scope = Span::wrap($context)->activate();
+
+        try {
+            $processor = new TraceIdProcessor();
+
+            $record = $processor->__invoke($this->makeArrayRecord());
+
+            $this->assertSame(str_repeat('a', 32), $record['extra']['trace_id']);
+        } finally {
+            $scope->detach();
+        }
+    }
+
+    private function makeRecord(): LogRecord
+    {
+        return new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'default',
+            level: Level::Info,
+            message: 'test message',
+        );
+    }
+
+    /**
+     * Legacy array-shaped record, as accepted by ProcessorInterface historically
+     * (Monolog 3.10 itself always builds LogRecord objects, but the processor
+     * still declares and handles the array branch defensively).
+     *
+     * @return array<string, mixed>
+     */
+    private function makeArrayRecord(): array
+    {
+        return [
+            'message' => 'test message',
+            'context' => [],
+            'level' => Level::Info->value,
+            'level_name' => Level::Info->getName(),
+            'channel' => 'default',
+            'datetime' => new \DateTimeImmutable(),
+            'extra' => [],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `App\Logging\TraceIdProcessor`, a Monolog processor that reads the active OpenTelemetry span via `Span::getCurrent()` and writes its trace ID into every log record's `extra.trace_id`.
- Wires the processor into all Monolog channels, including the `roadrunner` channel used as the production default (`MONOLOG_DEFAULT_CHANNEL=roadrunner`), which previously had no processors at all.
- Fixes several rotating file handlers (`error.log`, `http.log`, `debug.log`, `db.log`, `app.log`) whose formatter had no `%extra%` placeholder, which would have silently dropped `trace_id` from those log files.
- Deduplicates the trace-aware format string into `LoggingBootloader::LOG_FORMAT`, shared by `app/config/monolog.php`.

## Part of
Security/improvements TODO item P3-1 (API half — gateway half already shipped in #53).